### PR TITLE
feat: add meta-release reporting workflow v2 with Fall25/Spring25/Fall24 support

### DIFF
--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -64,38 +64,38 @@ on:
           - 'full-no-legacy'
         default: 'fall25'
       
-      include_prerelease:
-        description: 'Include pre-releases in the report'
-        required: false
-        type: boolean
-        default: true
-      
       recent_days_window:
-        description: 'Number of days for recent releases section (0 to exclude, max 365)'
+        description: 'Recent releases in last X days (0 to exclude)'
         required: false
         type: number
         default: 30
       
       show_repository_details:
-        description: 'Include detailed repository analysis section'
+        description: 'Detailed repository analysis'
         required: false
         type: boolean
         default: false
       
       show_prerelease_only_repos:
-        description: 'Show repositories with only pre-releases (no public releases)'
+        description: 'Repositories with only pre-releases'
         required: false
         type: boolean
         default: false
       
       show_repos_without_releases:
-        description: 'Show repositories without any releases'
+        description: 'Repositories without any releases'
         required: false
         type: boolean
         default: false
       
       include_consistency_analysis:
-        description: 'Include consistency analysis (checks for historic release issues)'
+        description: 'Consistency analysis (mainly historic)'
+        required: false
+        type: boolean
+        default: false
+      
+      exclude_prereleases:
+        description: 'Exclude pre-releases from repository details and consistency analysis'
         required: false
         type: boolean
         default: false
@@ -248,7 +248,7 @@ jobs:
             const groupId = ${{ matrix.group.id }};
             const repositories = ${{ toJson(matrix.group.repositories) }};
             const reportType = '${{ github.event.inputs.report_type }}' || 'full';
-            const includePrerelease = '${{ github.event.inputs.include_prerelease }}' === 'true';
+            const includePrerelease = '${{ github.event.inputs.exclude_prereleases }}' !== 'true';
             const includeConsistencyAnalysis = '${{ github.event.inputs.include_consistency_analysis }}' === 'true';
             let recentDaysWindow = parseInt('${{ github.event.inputs.recent_days_window }}') || 30;
             const showRepositoryDetails = '${{ github.event.inputs.show_repository_details }}' === 'true';
@@ -765,7 +765,7 @@ jobs:
       consistency_issues: ${{ steps.combine-results.outputs.consistency_issues }}
       unique_apis: ${{ steps.combine-results.outputs.unique_apis }}
       report_type: ${{ steps.combine-results.outputs.report_type }}
-      include_prerelease: ${{ steps.combine-results.outputs.include_prerelease }}
+      exclude_prereleases: ${{ steps.combine-results.outputs.exclude_prereleases }}
     steps:
       - name: Download All Group Results
         uses: actions/download-artifact@v4
@@ -1808,7 +1808,7 @@ jobs:
             core.setOutput('consistency_issues', consistencyIssues.length);
             core.setOutput('unique_apis', totals.apis.size);
             core.setOutput('report_type', filters.reportType);
-            core.setOutput('include_prerelease', filters.includePrerelease);
+            core.setOutput('exclude_prereleases', !filters.includePrerelease);
             
             console.log(`✅ Parallel API releases report saved as ${filename}`);
             console.log('📊 Final Statistics:');
@@ -1911,7 +1911,7 @@ jobs:
             echo "## ⚙️ Analysis Configuration" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Report Type**: ${{ needs.combine-api-analysis.outputs.report_type }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Include Pre-releases**: ${{ needs.combine-api-analysis.outputs.include_prerelease == 'true' && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Exclude Pre-releases**: ${{ needs.combine-api-analysis.outputs.exclude_prereleases == 'true' && '✅ Yes (from details/consistency)' || '❌ No (included everywhere)' }}" >> $GITHUB_STEP_SUMMARY
             echo "- **Meta-release Analysis**: ✅ Fall24, Spring25, Fall25 categorization" >> $GITHUB_STEP_SUMMARY
             echo "- **API Definitions**: ✅ Extracted from releases and main branch" >> $GITHUB_STEP_SUMMARY
             echo "- **Consistency Checks**: ✅ Main branch vs release comparison" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -485,8 +485,8 @@ jobs:
                     const versionMatch = content.match(/^\s*version:\s*['"]?v?([^'"\s]+)['"]?$/m);
                     const version = versionMatch ? versionMatch[1] : 'Unknown';
                     
-                    // Extract API name from server URL
-                    const serverMatch = content.match(/^\s*servers:\s*\n\s*-\s*url:\s*["']?\{[^}]+\}\/([^\/]+)/m);
+                    // Extract API name from server URL (only for direct path format)
+                    const serverMatch = content.match(/^\s*servers:\s*\n\s*-\s*url:\s*["']?\{[^}]+\}\/([a-z0-9-]+)/m);
                     const serverApiName = serverMatch ? serverMatch[1] : null;
                     
                     // Determine final API name and track mismatches
@@ -494,7 +494,8 @@ jobs:
                     let apiName = filenameApiName;
                     let hasNameMismatch = false;
                     
-                    if (serverApiName && serverApiName !== filenameApiName) {
+                    // Only use server URL if we have a clear match (ignore complex formats like {basePath})
+                    if (serverApiName && serverApiName !== filenameApiName && !serverApiName.includes('{')) {
                       console.log(`      ⚠️ API name mismatch: filename='${filenameApiName}' vs server='${serverApiName}' - using server URL`);
                       apiName = serverApiName;
                       hasNameMismatch = true;

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -1203,7 +1203,11 @@ jobs:
             report += utils.generateMarkdownTable(metaReleaseHeaders, metaReleaseRows);
             
             report += '\n';
-            report += '*Note: Legacy releases and pre-releases are excluded from API counts, except for Fall25*\n';
+            if (filters.reportType === 'full-no-legacy') {
+              report += '*Note: Legacy releases before Fall24 are excluded. Pre-releases are excluded from API counts, except for Fall25*\n';
+            } else {
+              report += '*Note: Legacy releases and pre-releases are excluded from API counts, except for Fall25*\n';
+            }
             if (allProcessingErrors.length > 0) {
               report += `*⚠️ Warning: ${allProcessingErrors.length} repositories could not be analyzed - numbers may be incomplete*\n`;
             }

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -55,18 +55,18 @@ on:
         required: true
         type: choice
         options:
-          - 'full'
-          - 'full-no-legacy'
           - 'fall25'
           - 'spring25'
           - 'fall24'
-        default: 'full'
+          - 'full'
+          - 'full-no-legacy'
+        default: 'fall25'
       
       include_prerelease:
         description: 'Include pre-releases in the report'
         required: false
         type: boolean
-        default: false
+        default: true
       
       include_consistency_analysis:
         description: 'Include consistency analysis (checks for historic release issues)'
@@ -82,6 +82,18 @@ on:
       
       show_repository_details:
         description: 'Include detailed repository analysis section'
+        required: false
+        type: boolean
+        default: false
+      
+      show_prerelease_only_repos:
+        description: 'Show repositories with only pre-releases (no public releases)'
+        required: false
+        type: boolean
+        default: false
+      
+      show_repos_without_releases:
+        description: 'Show repositories without any releases'
         required: false
         type: boolean
         default: false
@@ -237,7 +249,9 @@ jobs:
             const includePrerelease = '${{ github.event.inputs.include_prerelease }}' === 'true';
             const includeConsistencyAnalysis = '${{ github.event.inputs.include_consistency_analysis }}' === 'true';
             let recentDaysWindow = parseInt('${{ github.event.inputs.recent_days_window }}') || 30;
-            const showRepositoryDetails = '${{ github.event.inputs.show_repository_details }}' !== 'false';
+            const showRepositoryDetails = '${{ github.event.inputs.show_repository_details }}' === 'true';
+            const showPrereleaseOnlyRepos = '${{ github.event.inputs.show_prerelease_only_repos }}' === 'true';
+            const showReposWithoutReleases = '${{ github.event.inputs.show_repos_without_releases }}' === 'true';
             
             // Configuration from environment
             const config = {
@@ -296,6 +310,31 @@ jobs:
               isFall25Public: (date) => {
                 const d = new Date(date);
                 return d.getFullYear() === 2025 && (d.getMonth() === 7 || d.getMonth() === 8);
+              },
+              
+              // Validate kebab-case API names
+              isValidApiName: (name) => {
+                return /^[a-z]+(-[a-z]+)*$/.test(name);
+              },
+              
+              // Strip pre-release suffix (e.g., "1.0.0-rc.1" → "1.0.0")
+              getBaseVersion: (version) => {
+                return version.replace(/-.*$/, '');
+              },
+              
+              // Determine if API is initial (0.x) or stable (x.y where x≥1)
+              getApiMaturity: (version) => {
+                return version.startsWith('0.') ? 'initial' : 'stable';
+              },
+              
+              // Helper for consistent Markdown table generation
+              generateMarkdownTable: (headers, rows) => {
+                let table = `| ${headers.join(' | ')} |\n`;
+                table += `|${headers.map(() => '---').join('|')}|\n`;
+                rows.forEach(row => {
+                  table += `| ${row.join(' | ')} |\n`;
+                });
+                return table;
               }
             };
             
@@ -510,7 +549,9 @@ jobs:
                 includePrerelease: includePrerelease,
                 includeConsistencyAnalysis: includeConsistencyAnalysis,
                 recentDaysWindow: recentDaysWindow,
-                showRepositoryDetails: showRepositoryDetails
+                showRepositoryDetails: showRepositoryDetails,
+                showPrereleaseOnlyRepos: showPrereleaseOnlyRepos,
+                showReposWithoutReleases: showReposWithoutReleases
               }
             };
             
@@ -1134,23 +1175,47 @@ jobs:
               stats.apis.forEach(a => totals.apis.add(a));
             });
             
-            // Build the table
-            report += '| Metric | Fall24 | Spring25 | Fall25 | Other | Total |\n';
-            report += '|--------|--------|----------|--------|-------|-------|\n';
-            
-            // Repository count row
-            report += `| **Repositories** | ${metaReleaseStats['Fall24'].repos.size} | ${metaReleaseStats['Spring25'].repos.size} | ${metaReleaseStats['Fall25'].repos.size} | ${metaReleaseStats['Other'].repos.size} | ${totals.repos.size} |\n`;
-            
-            // Release type rows
-            report += `| **Pre-releases** | ${metaReleaseStats['Fall24'].preReleases} | ${metaReleaseStats['Spring25'].preReleases} | ${metaReleaseStats['Fall25'].preReleases} | ${metaReleaseStats['Other'].preReleases} | ${totals.preReleases} |\n`;
-            report += `| **Public Releases** | ${metaReleaseStats['Fall24'].publicReleases} | ${metaReleaseStats['Spring25'].publicReleases} | ${metaReleaseStats['Fall25'].publicReleases} | ${metaReleaseStats['Other'].publicReleases} | ${totals.publicReleases} |\n`;
-            report += `| **Patch Releases** | ${metaReleaseStats['Fall24'].patchReleases} | ${metaReleaseStats['Spring25'].patchReleases} | ${metaReleaseStats['Fall25'].patchReleases} | ${metaReleaseStats['Other'].patchReleases} | ${totals.patchReleases} |\n`;
-            
-            // Single API row showing unique APIs (with equivalence handling)
-            report += `| **Unique APIs** | ${countUniqueAPIs(metaReleaseStats['Fall24'].apis)} | ${countUniqueAPIs(metaReleaseStats['Spring25'].apis)} | ${countUniqueAPIs(metaReleaseStats['Fall25'].apis)} | ${countUniqueAPIs(metaReleaseStats['Other'].apis)} | ${countUniqueAPIs(totals.apis)} |\n`;
-            
-            // Cumulative APIs row (with equivalence handling)
-            report += `| **Cumulative APIs** | ${countUniqueAPIs(cumulativeAPIs['Fall24'])} | ${countUniqueAPIs(cumulativeAPIs['Spring25'])} | ${countUniqueAPIs(cumulativeAPIs['Fall25'])} | ${countUniqueAPIs(cumulativeAPIs['Other'])} | - |\n`;
+            // Build the Meta-Release Summary table using the utility function
+            const metaReleaseHeaders = ['Metric', 'Fall24', 'Spring25', 'Fall25', 'Other', 'Total'];
+            const metaReleaseRows = [
+              ['**Repositories**', 
+                metaReleaseStats['Fall24'].repos.size, 
+                metaReleaseStats['Spring25'].repos.size, 
+                metaReleaseStats['Fall25'].repos.size, 
+                metaReleaseStats['Other'].repos.size, 
+                totals.repos.size],
+              ['**Pre-releases**', 
+                metaReleaseStats['Fall24'].preReleases, 
+                metaReleaseStats['Spring25'].preReleases, 
+                metaReleaseStats['Fall25'].preReleases, 
+                metaReleaseStats['Other'].preReleases, 
+                totals.preReleases],
+              ['**Public Releases**', 
+                metaReleaseStats['Fall24'].publicReleases, 
+                metaReleaseStats['Spring25'].publicReleases, 
+                metaReleaseStats['Fall25'].publicReleases, 
+                metaReleaseStats['Other'].publicReleases, 
+                totals.publicReleases],
+              ['**Patch Releases**', 
+                metaReleaseStats['Fall24'].patchReleases, 
+                metaReleaseStats['Spring25'].patchReleases, 
+                metaReleaseStats['Fall25'].patchReleases, 
+                metaReleaseStats['Other'].patchReleases, 
+                totals.patchReleases],
+              ['**Unique APIs**', 
+                countUniqueAPIs(metaReleaseStats['Fall24'].apis), 
+                countUniqueAPIs(metaReleaseStats['Spring25'].apis), 
+                countUniqueAPIs(metaReleaseStats['Fall25'].apis), 
+                countUniqueAPIs(metaReleaseStats['Other'].apis), 
+                countUniqueAPIs(totals.apis)],
+              ['**Cumulative APIs**', 
+                countUniqueAPIs(cumulativeAPIs['Fall24']), 
+                countUniqueAPIs(cumulativeAPIs['Spring25']), 
+                countUniqueAPIs(cumulativeAPIs['Fall25']), 
+                countUniqueAPIs(cumulativeAPIs['Other']), 
+                '-']
+            ];
+            report += utils.generateMarkdownTable(metaReleaseHeaders, metaReleaseRows);
             
             report += '\n';
             report += '*Note: Legacy releases and pre-releases are excluded from API counts, except for Fall25*\n';
@@ -1204,7 +1269,7 @@ jobs:
                 targetReleases.forEach(release => {
                   release.api_definitions.forEach(api => {
                     // Skip non-kebab-case API names (they're likely old/incorrect naming)
-                    if (!api.name.match(/^[a-z]+(-[a-z]+)*$/)) return;
+                    if (!utils.isValidApiName(api.name)) return;
                     
                     // Only process each API once per repository (use latest data)
                     if (seenAPIs.has(api.name)) return;
@@ -1222,14 +1287,14 @@ jobs:
                         // Strip pre-release suffix to get target version
                         const preAPI = latestPreRelease.api_definitions.find(a => a.name === api.name);
                         if (preAPI) {
-                          targetVersion = preAPI.version.replace(/-.*$/, '');
+                          targetVersion = utils.getBaseVersion(preAPI.version);
                         } else {
-                          targetVersion = api.version.replace(/-.*$/, '');
+                          targetVersion = utils.getBaseVersion(api.version);
                         }
                       }
                       
                       // Determine maturity
-                      const maturity = targetVersion.startsWith('0.') ? 'initial' : 'stable';
+                      const maturity = utils.getApiMaturity(targetVersion);
                       
                       // Get current version (from latest release)
                       const currentAPI = latestRelease.api_definitions.find(a => a.name === api.name);
@@ -1243,7 +1308,7 @@ jobs:
                         const preAPI = latestPreRelease.api_definitions.find(a => a.name === api.name);
                         if (preAPI && preAPI.version.includes('-')) {
                           preReleaseTag = latestPreRelease.tag_name;
-                          preReleaseDate = new Date(latestPreRelease.published_at).toISOString().split('T')[0];
+                          preReleaseDate = utils.formatDate(latestPreRelease.published_at);
                           preReleaseUrl = latestPreRelease.html_url;
                         }
                       }
@@ -1256,7 +1321,7 @@ jobs:
                         new Date(a.published_at) - new Date(b.published_at))[0];
                       if (firstPublic) {
                         m4ReleaseTag = firstPublic.tag_name;
-                        m4ReleaseDate = new Date(firstPublic.published_at).toISOString().split('T')[0];
+                        m4ReleaseDate = utils.formatDate(firstPublic.published_at);
                         m4ReleaseUrl = firstPublic.html_url;
                       }
                       
@@ -1421,11 +1486,20 @@ jobs:
               }
             }
             
-            // Recent releases section - FIXED
+            // ============================================
+            // REPORT SECTION GENERATION - Phase 3 Reordered
+            // Order: Header -> Executive Summary -> Main Report (API Status or Meta-Release Summary)
+            //        -> Recent Releases -> Repository Details -> Pre-release Only -> Without Releases -> Consistency
+            // ============================================
+            
+            // Prepare all sections first, then assemble in the correct order
+            
+            // Section 4: Recent Releases (conditional)
+            let recentReleasesSection = '';
             if (recentReleases.length > 0 && filters.recentDaysWindow > 0) {
-              report += `## Recent Releases (Last ${filters.recentDaysWindow} Days)\n\n`;
-              report += '| Repository | Repo Type | Release | Type | APIs | Date | Meta-Release |\n';
-              report += '|------------|-----------|---------|------|------|------|-------------|\n';
+              recentReleasesSection += `## Recent Releases (Last ${filters.recentDaysWindow} Days)\n\n`;
+              recentReleasesSection += '| Repository | Repo Type | Release | Type | APIs | Date | Meta-Release |\n';
+              recentReleasesSection += '|------------|-----------|---------|------|------|------|-------------|\n';
               
               recentReleases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
               
@@ -1447,20 +1521,21 @@ jobs:
                 const metaRelease = release.meta_release.cycle;
                 
                 // FIXED: Use the stored repository information instead of trying to find it
-                report += `| [${release.repository_name}](${release.repository_html_url}) | ${release.repository_type} | [${name}](${release.html_url}) | ${typeDisplay} | ${apiList} | ${date} | ${metaRelease} |\n`;
+                recentReleasesSection += `| [${release.repository_name}](${release.repository_html_url}) | ${release.repository_type} | [${name}](${release.html_url}) | ${typeDisplay} | ${apiList} | ${date} | ${metaRelease} |\n`;
               }
-              report += '\n';
+              recentReleasesSection += '\n';
             }
             
-            // Consistency analysis (only if requested)
+            // Section 8: Consistency Analysis (conditional - moved to end in Phase 3)
             const consistencyIssues = [];
+            let consistencySection = '';
             
             if (filters.includeConsistencyAnalysis) {
-              report += '## Consistency Analysis\n\n';
+              consistencySection += '## Consistency Analysis\n\n';
               if (filters.reportType !== 'full') {
-                report += `*Note: This analysis is filtered to ${filters.reportType} repositories only*\n\n`;
+                consistencySection += `*Note: This analysis is filtered to ${filters.reportType} repositories only*\n\n`;
               } else if (!filters.includePrerelease) {
-                report += '*Note: This analysis reflects applied filters - pre-releases are excluded*\n\n';
+                consistencySection += '*Note: This analysis reflects applied filters - pre-releases are excluded*\n\n';
               }
             
             // Use filtered repositories based on report type
@@ -1531,38 +1606,39 @@ jobs:
             }
             
             if (consistencyIssues.length > 0) {
-              report += '### Consistency Issues Found\n\n';
-              report += '| Repository | Issue Type | Description |\n';
-              report += '|------------|------------|-------------|\n';
+              consistencySection += '### Consistency Issues Found\n\n';
+              consistencySection += '| Repository | Issue Type | Description |\n';
+              consistencySection += '|------------|------------|-------------|\n';
               
               for (const issue of consistencyIssues.slice(0, 20)) {
-                report += `| ${issue.repo} | ${issue.type} | ${issue.description} |\n`;
+                consistencySection += `| ${issue.repo} | ${issue.type} | ${issue.description} |\n`;
               }
               
               if (consistencyIssues.length > 20) {
-                report += `\n*Showing first 20 of ${consistencyIssues.length} issues*\n`;
+                consistencySection += `\n*Showing first 20 of ${consistencyIssues.length} issues*\n`;
               }
-              report += '\n';
+              consistencySection += '\n';
             } else {
-              report += '✅ No consistency issues found!\n\n';
+              consistencySection += '✅ No consistency issues found!\n\n';
             }
             } // End of consistency analysis if block
             
-            // Detailed repository analysis (optional)
+            // Section 5: Detailed Repository Analysis (conditional)
+            let repositoryDetailsSection = '';
             if (filters.showRepositoryDetails) {
-              report += '## Detailed Repository Analysis\n\n';
+              repositoryDetailsSection += '## Detailed Repository Analysis\n\n';
             
             // Add filter note if not showing everything
             if (filters.reportType !== 'full' || !filters.includePrerelease) {
-              report += '*Note: ';
+              repositoryDetailsSection += '*Note: ';
               if (filters.reportType !== 'full') {
-                report += `Showing ${filters.reportType} repositories`;
+                repositoryDetailsSection += `Showing ${filters.reportType} repositories`;
               }
               if (!filters.includePrerelease) {
-                if (filters.reportType !== 'full') report += ' and ';
-                report += 'pre-releases are excluded';
+                if (filters.reportType !== 'full') repositoryDetailsSection += ' and ';
+                repositoryDetailsSection += 'pre-releases are excluded';
               }
-              report += '*\n\n';
+              repositoryDetailsSection += '*\n\n';
             }
             
             // Use filtered repositories for details
@@ -1591,19 +1667,19 @@ jobs:
               if (filteredReleases.length === 0) continue;
               
               // Don't show type (Sandbox/Incubating) in title for cleaner output
-              report += `### [${repo.name}](${repo.html_url})\n\n`;
+              repositoryDetailsSection += `### [${repo.name}](${repo.html_url})\n\n`;
               
               if (repo.main_branch_apis.length > 0) {
-                report += '**Main Branch APIs:**\n';
+                repositoryDetailsSection += '**Main Branch APIs:**\n';
                 for (const api of repo.main_branch_apis) {
-                  report += `- ${api.name}: v${api.version}\n`;
+                  repositoryDetailsSection += `- ${api.name}: v${api.version}\n`;
                 }
-                report += '\n';
+                repositoryDetailsSection += '\n';
               }
               
-              report += '**Release History:**\n';
-              report += '| Release | Date | Type | Meta-Release | APIs |\n';
-              report += '|---------|------|------|--------------|------|\n';
+              repositoryDetailsSection += '**Release History:**\n';
+              repositoryDetailsSection += '| Release | Date | Type | Meta-Release | APIs |\n';
+              repositoryDetailsSection += '|---------|------|------|--------------|------|\n';
               
               for (const release of filteredReleases.slice(0, 5)) {
                 const date = new Date(release.published_at).toLocaleDateString();
@@ -1621,15 +1697,16 @@ jobs:
                 
                 const apiList = release.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
                 
-                report += `| [${release.tag_name}](${release.html_url}) | ${date} | ${typeDisplay} | ${metaRelease} | ${apiList} |\n`;
+                repositoryDetailsSection += `| [${release.tag_name}](${release.html_url}) | ${date} | ${typeDisplay} | ${metaRelease} | ${apiList} |\n`;
               }
-              report += '\n';
+              repositoryDetailsSection += '\n';
             }
             
             } // End of showRepositoryDetails conditional
             
-            // Repositories with pre-releases only - show when pre-releases are included
-            if (filters.includePrerelease && allRepositoriesWithPrereleasesOnly.length > 0) {
+            // Section 6: Pre-release Only Repositories (conditional - new position in Phase 3)
+            let prereleaseOnlySection = '';
+            if (filters.showPrereleaseOnlyRepos && allRepositoriesWithPrereleasesOnly.length > 0) {
               // Filter pre-release-only repos based on report type
               let filteredPreReleaseRepos = allRepositoriesWithPrereleasesOnly;
               
@@ -1669,33 +1746,65 @@ jobs:
               }
               
               if (filteredPreReleaseRepos.length > 0) {
-                report += '## API Repositories with Pre-releases Only\n\n';
-                report += '*These repositories have releases but only pre-releases, no public releases yet.*\n\n';
-                report += '| Repository | Type | Pre-releases | Main Branch APIs | Pre-release APIs |\n';
-                report += '|------------|------|--------------|------------------|-----------------|\n';
+                prereleaseOnlySection += '## API Repositories with Pre-releases Only\n\n';
+                prereleaseOnlySection += '*These repositories have releases but only pre-releases, no public releases yet.*\n\n';
+                prereleaseOnlySection += '| Repository | Type | Pre-releases | Main Branch APIs | Pre-release APIs |\n';
+                prereleaseOnlySection += '|------------|------|--------------|------------------|-----------------|\n';
                 
                 for (const repo of filteredPreReleaseRepos.sort((a, b) => a.name.localeCompare(b.name))) {
                   const mainAPIs = repo.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
                   const prereleaseAPIs = repo.prerelease_apis.join('<br>');
                   
-                  report += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${repo.prerelease_count} | ${mainAPIs} | ${prereleaseAPIs} |\n`;
+                  prereleaseOnlySection += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${repo.prerelease_count} | ${mainAPIs} | ${prereleaseAPIs} |\n`;
                 }
-                report += '\n';
+                prereleaseOnlySection += '\n';
               }
             }
             
-            // Repositories without releases
-            if (allRepositoriesWithoutReleases.length > 0) {
-              report += '## API Repositories Without Releases\n\n';
-              report += '| Repository | Type | API Definitions Found |\n';
-              report += '|------------|------|-----------------------|\n';
+            // Section 7: Repositories Without Releases (conditional - new position in Phase 3)
+            let reposWithoutReleasesSection = '';
+            if (filters.showReposWithoutReleases && allRepositoriesWithoutReleases.length > 0) {
+              reposWithoutReleasesSection += '## API Repositories Without Releases\n\n';
+              reposWithoutReleasesSection += '| Repository | Type | API Definitions Found |\n';
+              reposWithoutReleasesSection += '|------------|------|-----------------------|\n';
               
               for (const repo of allRepositoriesWithoutReleases.sort((a, b) => a.name.localeCompare(b.name))) {
                 const apiList = repo.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
                 
-                report += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${apiList} |\n`;
+                reposWithoutReleasesSection += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${apiList} |\n`;
               }
-              report += '\n';
+              reposWithoutReleasesSection += '\n';
+            }
+            
+            // ============================================
+            // FINAL REPORT ASSEMBLY - Phase 3 Order
+            // ============================================
+            // Sections 1-3 are already in 'report' variable (Header, Executive Summary, Main Report)
+            // Now append the conditional sections in the new order:
+            
+            // Section 4: Recent Releases
+            if (recentReleasesSection) {
+              report += recentReleasesSection;
+            }
+            
+            // Section 5: Repository Details
+            if (repositoryDetailsSection) {
+              report += repositoryDetailsSection;
+            }
+            
+            // Section 6: Pre-release Only Repos
+            if (prereleaseOnlySection) {
+              report += prereleaseOnlySection;
+            }
+            
+            // Section 7: Repos Without Releases
+            if (reposWithoutReleasesSection) {
+              report += reposWithoutReleasesSection;
+            }
+            
+            // Section 8: Consistency Analysis (moved to end)
+            if (consistencySection) {
+              report += consistencySection;
             }
             
             // Save final report

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -1,23 +1,25 @@
 # =========================================================================================
-# CAMARA Project - API Releases Report Workflow
+# CAMARA Project - Meta-Release Reporting Workflow v2
 #
-# This GitHub Actions workflow analyzes API releases across CAMARA repositories with
-# parallel processing, meta-release categorization, and consistency validation.
+# This enhanced GitHub Actions workflow provides comprehensive API release tracking
+# aligned with CAMARA meta-release milestones (Fall25, Spring25, Fall24) with
+# parallel processing, consistency validation, and JSON export capabilities.
 #
 # CHANGELOG:
-# - 2025-07-26: Initial version for r1.1 release
+# - 2025-09-08: v2 - Meta-release support, enhanced reporting, JSON export
+# - 2025-07-26: v1 - Initial version for r1.1 release
 #
 # USAGE:
 # - Manually triggered via workflow_dispatch
-# - Options: include pre-releases, include legacy releases
-# - Uses parallel processing for 70% faster execution (3-5 minutes)
+# - Default: Fall25 meta-release report with pre-releases included
+# - Uses parallel processing for fast execution (3-5 minutes)
 # - Requires CAMARA_REPORT_TOKEN for cross-repository access
 #
 # DOCUMENTATION:
-# see https://github.com/camaraproject/project-administration/blob/main/documentation/project-report-generation-workflows.md
+# see https://github.com/camaraproject/project-administration/blob/main/documentation/meta-release-reporting-workflow.md
 # =========================================================================================
 
-name: CAMARA API Releases
+name: Meta-Release Reporting v2
 
 env:
   # =========================================================================================
@@ -68,12 +70,6 @@ on:
         type: boolean
         default: true
       
-      include_consistency_analysis:
-        description: 'Include consistency analysis (checks for historic release issues)'
-        required: false
-        type: boolean
-        default: false
-      
       recent_days_window:
         description: 'Number of days for recent releases section (0 to exclude, max 365)'
         required: false
@@ -94,6 +90,12 @@ on:
       
       show_repos_without_releases:
         description: 'Show repositories without any releases'
+        required: false
+        type: boolean
+        default: false
+      
+      include_consistency_analysis:
+        description: 'Include consistency analysis (checks for historic release issues)'
         required: false
         type: boolean
         default: false
@@ -278,21 +280,10 @@ jobs:
             // UTILITY FUNCTIONS
             // ============================================
             
-            // Common utility functions used throughout the workflow
+            // Utility functions used in analyze-api-repositories job
             const utils = {
               // Delay execution for rate limiting
               delay: (ms) => new Promise(resolve => setTimeout(resolve, ms)),
-              
-              // Check if a date falls within a window
-              isInDateWindow: (date, startStr, endStr) => {
-                const d = new Date(date);
-                const start = new Date(startStr);
-                const end = new Date(endStr);
-                return d >= start && d <= end;
-              },
-              
-              // Format date to YYYY-MM-DD
-              formatDate: (date) => new Date(date).toISOString().split('T')[0],
               
               // Check if date is in Fall24 window
               isFall24: (date) => {
@@ -310,31 +301,6 @@ jobs:
               isFall25Public: (date) => {
                 const d = new Date(date);
                 return d.getFullYear() === 2025 && (d.getMonth() === 7 || d.getMonth() === 8);
-              },
-              
-              // Validate kebab-case API names
-              isValidApiName: (name) => {
-                return /^[a-z]+(-[a-z]+)*$/.test(name);
-              },
-              
-              // Strip pre-release suffix (e.g., "1.0.0-rc.1" → "1.0.0")
-              getBaseVersion: (version) => {
-                return version.replace(/-.*$/, '');
-              },
-              
-              // Determine if API is initial (0.x) or stable (x.y where x≥1)
-              getApiMaturity: (version) => {
-                return version.startsWith('0.') ? 'initial' : 'stable';
-              },
-              
-              // Helper for consistent Markdown table generation
-              generateMarkdownTable: (headers, rows) => {
-                let table = `| ${headers.join(' | ')} |\n`;
-                table += `|${headers.map(() => '---').join('|')}|\n`;
-                rows.forEach(row => {
-                  table += `| ${row.join(' | ')} |\n`;
-                });
-                return table;
               }
             };
             
@@ -800,7 +766,6 @@ jobs:
       unique_apis: ${{ steps.combine-results.outputs.unique_apis }}
       report_type: ${{ steps.combine-results.outputs.report_type }}
       include_prerelease: ${{ steps.combine-results.outputs.include_prerelease }}
-      include_dev_status: ${{ steps.combine-results.outputs.include_dev_status }}
     steps:
       - name: Download All Group Results
         uses: actions/download-artifact@v4
@@ -820,6 +785,37 @@ jobs:
             // Parse API equivalences from environment variable
             const API_EQUIVALENCES = JSON.parse(process.env.API_EQUIVALENCES || '[]');
             console.log('📊 API Equivalences loaded:', API_EQUIVALENCES);
+            
+            // Utility functions used in combine-api-analysis job
+            const utils = {
+              // Helper for consistent Markdown table generation
+              generateMarkdownTable: (headers, rows) => {
+                let table = `| ${headers.join(' | ')} |\n`;
+                table += `|${headers.map(() => '---').join('|')}|\n`;
+                rows.forEach(row => {
+                  table += `| ${row.join(' | ')} |\n`;
+                });
+                return table;
+              },
+              
+              // Validate kebab-case API names
+              isValidApiName: (name) => {
+                return /^[a-z]+(-[a-z]+)*$/.test(name);
+              },
+              
+              // Strip pre-release suffix (e.g., "1.0.0-rc.1" → "1.0.0")
+              getBaseVersion: (version) => {
+                return version.replace(/-.*$/, '');
+              },
+              
+              // Determine if API is initial (0.x) or stable (x.y where x≥1)
+              getApiMaturity: (version) => {
+                return version.startsWith('0.') ? 'initial' : 'stable';
+              },
+              
+              // Format date to YYYY-MM-DD
+              formatDate: (date) => new Date(date).toISOString().split('T')[0]
+            };
             
             // Helper function to count unique APIs considering name equivalences
             function countUniqueAPIs(apiSet) {
@@ -1048,7 +1044,7 @@ jobs:
             
             // Show applied filters
             report += `**Filters Applied**: `;
-            report += `Include Pre-releases: ${filters.includePrerelease ? 'Yes' : 'No'}, `;
+            report += `Include Pre-releases: ${filters.includePrerelease ? 'Yes' : 'No'}\n\n`;
             
             // Executive Summary Table
             report += '## Executive Summary\n\n';
@@ -1117,8 +1113,7 @@ jobs:
               });
             });
             
-            const legacyIncluded = filters.reportType !== 'full-no-legacy';
-            report += `| **Total Releases Analyzed** | ${totalReleasesAnalyzed} | ${filters.includePrerelease ? 'Including' : 'Excluding'} pre-releases, ${legacyIncluded ? 'including' : 'excluding'} legacy |\n`;
+            report += `| **Total Releases Analyzed** | ${totalReleasesAnalyzed} | ${filters.includePrerelease ? 'Including' : 'Excluding'} pre-releases, ${filters.reportType !== 'full-no-legacy' ? 'including' : 'excluding'} legacy |\n`;
             
             if (allProcessingErrors.length > 0) {
               report += `| **Processing Errors** | ${allProcessingErrors.length} | Repositories with analysis errors |\n`;
@@ -1532,7 +1527,9 @@ jobs:
             
             if (filters.includeConsistencyAnalysis) {
               consistencySection += '## Consistency Analysis\n\n';
-              if (filters.reportType !== 'full') {
+              if (filters.reportType === 'full-no-legacy') {
+                consistencySection += '*Note: This analysis excludes legacy releases before Fall24*\n\n';
+              } else if (filters.reportType !== 'full') {
                 consistencySection += `*Note: This analysis is filtered to ${filters.reportType} repositories only*\n\n`;
               } else if (!filters.includePrerelease) {
                 consistencySection += '*Note: This analysis reflects applied filters - pre-releases are excluded*\n\n';
@@ -1631,7 +1628,9 @@ jobs:
             // Add filter note if not showing everything
             if (filters.reportType !== 'full' || !filters.includePrerelease) {
               repositoryDetailsSection += '*Note: ';
-              if (filters.reportType !== 'full') {
+              if (filters.reportType === 'full-no-legacy') {
+                repositoryDetailsSection += 'Legacy releases before Fall24 excluded';
+              } else if (filters.reportType !== 'full') {
                 repositoryDetailsSection += `Showing ${filters.reportType} repositories`;
               }
               if (!filters.includePrerelease) {
@@ -1816,7 +1815,7 @@ jobs:
             core.setOutput('total_api_repos', totalApiRepos);
             core.setOutput('repos_with_releases', allRepositories.length);
             core.setOutput('repos_without_releases', allRepositoriesWithoutReleases.length);
-            core.setOutput('repos_prerelease_only', allRepositoriesWithPrereleasesOnly.length);
+            core.setOutput('repos_prerelease_only', allPreReleaseOnlyRepos.length);
             core.setOutput('total_releases', totalReleasesAnalyzed);
             core.setOutput('recent_releases', recentReleases.length);
             core.setOutput('consistency_issues', consistencyIssues.length);
@@ -1849,20 +1848,26 @@ jobs:
             
             console.log('🎉 Parallel CAMARA API releases report generation completed!');
 
-      - name: Upload Final API Releases Report
+      - name: Upload Markdown Report
         uses: actions/upload-artifact@v4
         with:
-          name: camara-api-releases-${{ github.run_number }}
-          path: |
-            *.md
-            api-status-*.json
+          name: camara-api-releases-report-${{ github.run_number }}
+          path: '*.md'
+          retention-days: 90
+      
+      - name: Upload JSON Data
+        if: ${{ contains('fall25,spring25,fall24', github.event.inputs.report_type) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: camara-api-releases-json-${{ github.run_number }}
+          path: 'api-status-*.json'
           retention-days: 90
 
   # ============================================
   # JOB 4: WORKFLOW SUMMARY
   # Purpose: Generate final execution summary for GitHub Actions UI
   # ============================================
-  final-summary:
+  workflow-summary:
     if: always()
     needs: [generate-report, combine-api-analysis]
     runs-on: ubuntu-latest
@@ -1877,44 +1882,60 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           
           if [ "${{ needs.combine-api-analysis.result }}" = "success" ]; then
-            echo "## 📊 API Release Statistics" >> $GITHUB_STEP_SUMMARY
+            echo "## 📥 Download Artifacts" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
-            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-            echo "| **API Repositories Analyzed** | ${{ needs.combine-api-analysis.outputs.total_api_repos }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Repositories with Releases** | ${{ needs.combine-api-analysis.outputs.repos_with_releases }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Repositories with Pre-releases Only** | ${{ needs.combine-api-analysis.outputs.repos_prerelease_only }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Repositories without Releases** | ${{ needs.combine-api-analysis.outputs.repos_without_releases }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Total Releases Analyzed** | ${{ needs.combine-api-analysis.outputs.total_releases }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Recent Releases (${{ github.event.inputs.recent_days_window || '30' }} days)** | ${{ needs.combine-api-analysis.outputs.recent_releases }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Unique APIs Found** | ${{ needs.combine-api-analysis.outputs.unique_apis }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Consistency Issues** | ${{ needs.combine-api-analysis.outputs.consistency_issues }} |" >> $GITHUB_STEP_SUMMARY
+            
+            # Check if JSON is available (only for meta-release reports)
+            if [[ "${{ github.event.inputs.report_type }}" == "fall25" ]] || \
+               [[ "${{ github.event.inputs.report_type }}" == "spring25" ]] || \
+               [[ "${{ github.event.inputs.report_type }}" == "fall24" ]]; then
+              echo "### Available Artifacts:" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Artifact | Description | Direct Link |" >> $GITHUB_STEP_SUMMARY
+              echo "|----------|-------------|------------|" >> $GITHUB_STEP_SUMMARY
+              echo "| **Markdown Report** | Complete detailed analysis report | [📄 Download Report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |" >> $GITHUB_STEP_SUMMARY
+              echo "| **JSON Data** | Machine-readable API status data for visualization | [📊 Download JSON](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Artifact Names:**" >> $GITHUB_STEP_SUMMARY
+              echo "- Report: \`camara-api-releases-report-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+              echo "- JSON: \`camara-api-releases-json-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### 🔗 Viewer Integration" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "To use the JSON data in the API Status Viewer:" >> $GITHUB_STEP_SUMMARY
+              echo "1. Download the JSON artifact (\`camara-api-releases-json-${{ github.run_number }}\`)" >> $GITHUB_STEP_SUMMARY
+              echo "2. Open the [API Status Viewer](https://camaraproject.github.io/api-status-viewer/)" >> $GITHUB_STEP_SUMMARY
+              echo "3. Upload or paste the JSON file content" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Direct Viewer Link:** *(will come soon)*" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### Available Artifact:" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Artifact | Description | Direct Link |" >> $GITHUB_STEP_SUMMARY
+              echo "|----------|-------------|------------|" >> $GITHUB_STEP_SUMMARY
+              echo "| **Markdown Report** | Complete detailed analysis report | [📄 Download Report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Artifact Name:** \`camara-api-releases-report-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "*Note: JSON export is only available for meta-release reports (Fall25, Spring25, Fall24)*" >> $GITHUB_STEP_SUMMARY
+            fi
             echo "" >> $GITHUB_STEP_SUMMARY
             
             echo "## ⚙️ Analysis Configuration" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            
             echo "- **Report Type**: ${{ needs.combine-api-analysis.outputs.report_type }}" >> $GITHUB_STEP_SUMMARY
             echo "- **Include Pre-releases**: ${{ needs.combine-api-analysis.outputs.include_prerelease == 'true' && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Include Dev Status**: ${{ needs.combine-api-analysis.outputs.include_dev_status == 'true' && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
-            
             echo "- **Meta-release Analysis**: ✅ Fall24, Spring25, Fall25 categorization" >> $GITHUB_STEP_SUMMARY
             echo "- **API Definitions**: ✅ Extracted from releases and main branch" >> $GITHUB_STEP_SUMMARY
             echo "- **Consistency Checks**: ✅ Main branch vs release comparison" >> $GITHUB_STEP_SUMMARY
-            
             echo "" >> $GITHUB_STEP_SUMMARY
+            
             echo "## ⚡ Performance" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Processing Time**: ~3-5 minutes (vs 15-20 minutes sequential)" >> $GITHUB_STEP_SUMMARY
             echo "- **Parallel Groups**: ${{ needs.generate-report.outputs.total_groups }}" >> $GITHUB_STEP_SUMMARY
             echo "- **Repositories per Group**: 8" >> $GITHUB_STEP_SUMMARY
             echo "- **Max Parallel**: 6 groups simultaneously" >> $GITHUB_STEP_SUMMARY
-            
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "## 📥 Download Report" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The complete detailed report is available in the **Artifacts** section below." >> $GITHUB_STEP_SUMMARY
-            echo "Look for: \`camara-api-releases-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
             
           else
             echo "## ❌ Workflow Failed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -884,13 +884,9 @@ jobs:
             // Repositories with public releases (never includes pre-release-only repos)
             const reposWithPublicReleases = allRepositories.filter(repo => repo.has_public_releases);
             
-            // Repositories with ONLY pre-releases (no public releases)
-            const reposWithOnlyPreReleases = allRepositories.filter(repo => 
-              !repo.has_public_releases && repo.has_prereleases
-            );
-            
-            // Combine pre-release-only repos from both sources
-            const allPreReleaseOnlyRepos = [...reposWithOnlyPreReleases, ...allRepositoriesWithPrereleasesOnly];
+            // allRepositoriesWithPrereleasesOnly already contains all repos with only pre-releases
+            // No need to filter or combine - it's already complete from parallel processing
+            const allPreReleaseOnlyRepos = allRepositoriesWithPrereleasesOnly;
             
             // Deduplicate all repositories for total count
             const allRepoNames = new Set();
@@ -1012,11 +1008,8 @@ jobs:
               report += `**Filtered Repositories**: ${filteredRepositories.length} of ${allRepositories.length}\n`;
             }
             
+            // Basic metadata - details will be in Executive Summary
             report += `**API Repositories Analyzed**: ${totalApiRepos}\n`;
-            report += `**Repositories with Releases**: ${reposWithPublicReleases.length}\n`;
-            
-            report += `**Repositories with Pre-releases Only**: ${allPreReleaseOnlyRepos.length}\n`;
-            report += `**Repositories without Releases**: ${allRepositoriesWithoutReleases.length}\n`;
             
             if (allProcessingErrors.length > 0) {
               report += `**Processing Errors**: ${allProcessingErrors.length}\n`;

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -997,15 +997,9 @@ jobs:
             
             report += `**Generated**: ${new Date().toISOString()}\n`;
             
-            // Add report-specific metadata
-            if (filters.reportType !== 'full') {
-              report += `**Report Type**: ${filters.reportType.charAt(0).toUpperCase() + filters.reportType.slice(1).replace('-', ' ')}\n`;
-              
-              if (filters.reportType === 'fall25') {
-                report += '**Pre-release Window**: 2025-07-10 to 2025-08-13\n';
-              }
-              
-              report += `**Filtered Repositories**: ${filteredRepositories.length} of ${allRepositories.length}\n`;
+            // Add report-specific metadata for Fall25 pre-release window
+            if (filters.reportType === 'fall25') {
+              report += '**Fall25 Pre-release Window**: 2025-07-10 to 2025-08-13\n';
             }
             
             // Basic metadata - details will be in Executive Summary

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -1517,12 +1517,20 @@ jobs:
             
             if (filters.includeConsistencyAnalysis) {
               consistencySection += '## Consistency Analysis\n\n';
+              
+              // Build note based on active filters
+              let notes = [];
               if (filters.reportType === 'full-no-legacy') {
-                consistencySection += '*Note: This analysis excludes legacy releases before Fall24*\n\n';
+                notes.push('This analysis excludes legacy releases before Fall24');
               } else if (filters.reportType !== 'full') {
-                consistencySection += `*Note: This analysis is filtered to ${filters.reportType} repositories only*\n\n`;
-              } else if (!filters.includePrerelease) {
-                consistencySection += '*Note: This analysis reflects applied filters - pre-releases are excluded*\n\n';
+                notes.push(`This analysis is filtered to ${filters.reportType} repositories only`);
+              }
+              if (!filters.includePrerelease) {
+                notes.push('pre-releases are excluded');
+              }
+              
+              if (notes.length > 0) {
+                consistencySection += `*Note: ${notes.join(' and ')}*\n\n`;
               }
             
             // Use filtered repositories based on report type

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -1,18 +1,18 @@
 # =========================================================================================
 # CAMARA Project - Meta-Release Reporting Workflow v2
 #
-# This enhanced GitHub Actions workflow provides comprehensive API release tracking
-# aligned with CAMARA meta-release milestones (Fall25, Spring25, Fall24) with
-# parallel processing, consistency validation, and JSON export capabilities.
+# GitHub Actions workflow for API release tracking aligned with CAMARA meta-release 
+# milestones (Fall25, Spring25, Fall24) with parallel processing, consistency 
+# validation, and JSON export.
 #
 # CHANGELOG:
-# - 2025-09-08: v2 - Meta-release support, enhanced reporting, JSON export
+# - 2025-09-08: v2 - Meta-release support, additional reporting sections, JSON export
 # - 2025-07-26: v1 - Initial version for r1.1 release
 #
 # USAGE:
 # - Manually triggered via workflow_dispatch
 # - Default: Fall25 meta-release report with pre-releases included
-# - Uses parallel processing for fast execution (3-5 minutes)
+# - Uses parallel processing (execution time: ~2 minutes)
 # - Requires CAMARA_REPORT_TOKEN for cross-repository access
 #
 # DOCUMENTATION:

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -250,7 +250,10 @@ jobs:
             const reportType = '${{ github.event.inputs.report_type }}' || 'full';
             const includePrerelease = '${{ github.event.inputs.exclude_prereleases }}' !== 'true';
             const includeConsistencyAnalysis = '${{ github.event.inputs.include_consistency_analysis }}' === 'true';
-            let recentDaysWindow = parseInt('${{ github.event.inputs.recent_days_window }}') || 30;
+            let recentDaysWindow = parseInt('${{ github.event.inputs.recent_days_window }}');
+            if (isNaN(recentDaysWindow)) {
+              recentDaysWindow = 30;
+            }
             const showRepositoryDetails = '${{ github.event.inputs.show_repository_details }}' === 'true';
             const showPrereleaseOnlyRepos = '${{ github.event.inputs.show_prerelease_only_repos }}' === 'true';
             const showReposWithoutReleases = '${{ github.event.inputs.show_repos_without_releases }}' === 'true';

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -481,10 +481,24 @@ jobs:
                     
                     const content = Buffer.from(fileContent.data.content, 'base64').toString('utf8');
                     
-                    // Extract version using regex for YAML format
-                    const versionMatch = content.match(/^\s*version:\s*['"]?([^'"\s]+)['"]?$/m);
+                    // Extract version and strip 'v' prefix if present (Fix 3)
+                    const versionMatch = content.match(/^\s*version:\s*['"]?v?([^'"\s]+)['"]?$/m);
                     const version = versionMatch ? versionMatch[1] : 'Unknown';
-                    const apiName = file.name.replace(/\.(yaml|yml)$/, '');
+                    
+                    // Extract API name from server URL
+                    const serverMatch = content.match(/^\s*servers:\s*\n\s*-\s*url:\s*["']?\{[^}]+\}\/([^\/]+)/m);
+                    const serverApiName = serverMatch ? serverMatch[1] : null;
+                    
+                    // Determine final API name and track mismatches
+                    const filenameApiName = file.name.replace(/\.(yaml|yml)$/, '');
+                    let apiName = filenameApiName;
+                    let hasNameMismatch = false;
+                    
+                    if (serverApiName && serverApiName !== filenameApiName) {
+                      console.log(`      ⚠️ API name mismatch: filename='${filenameApiName}' vs server='${serverApiName}' - using server URL`);
+                      apiName = serverApiName;
+                      hasNameMismatch = true;
+                    }
                     
                     console.log(`      ✅ ${apiName}: v${version}`);
                     
@@ -492,7 +506,10 @@ jobs:
                       name: apiName,
                       version: version,
                       filename: file.name,
-                      path: file.path
+                      path: file.path,
+                      hasNameMismatch: hasNameMismatch,
+                      filenameApiName: hasNameMismatch ? filenameApiName : null,
+                      serverApiName: hasNameMismatch ? serverApiName : null
                     });
                   } catch (error) {
                     console.log(`      ⚠️ Could not read ${file.name}: ${error.message}`);
@@ -1248,14 +1265,40 @@ jobs:
                 // Sort releases by date (newest first)
                 targetReleases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
                 
-                // Find the latest public release and latest pre-release
+                // Determine which releases to use for API collection:
+                // - If public release exists: use only the public release
+                // - If only pre-releases exist: use only the highest r.Y pre-release
                 const latestPublic = targetReleases.find(r => !r.prerelease);
-                const latestPreRelease = targetReleases.find(r => r.prerelease);
-                const latestRelease = targetReleases[0];
                 
-                // Process APIs from this repository
+                // Find the highest pre-release (by r.Y value) if no public release
+                let highestPreRelease = null;
+                if (!latestPublic) {
+                  const preReleases = targetReleases.filter(r => r.prerelease);
+                  if (preReleases.length > 0) {
+                    // Sort by r.Y value (extract Y from rX.Y tag)
+                    preReleases.sort((a, b) => {
+                      const aMatch = a.tag_name.match(/^r\d+\.(\d+)/);
+                      const bMatch = b.tag_name.match(/^r\d+\.(\d+)/);
+                      const aY = aMatch ? parseInt(aMatch[1]) : 0;
+                      const bY = bMatch ? parseInt(bMatch[1]) : 0;
+                      return bY - aY; // Descending order
+                    });
+                    highestPreRelease = preReleases[0];
+                  }
+                }
+                
+                // Determine which release(s) to use for API collection
+                const releasesToProcess = latestPublic 
+                  ? [latestPublic]  // Only the public release
+                  : (highestPreRelease ? [highestPreRelease] : []);  // Only the highest pre-release
+                
+                // For backwards compatibility, keep these variables
+                const latestPreRelease = highestPreRelease;
+                const latestRelease = latestPublic || highestPreRelease;
+                
+                // Process APIs from selected releases only
                 const seenAPIs = new Set();
-                targetReleases.forEach(release => {
+                releasesToProcess.forEach(release => {
                   release.api_definitions.forEach(api => {
                     // Skip non-kebab-case API names (they're likely old/incorrect naming)
                     if (!utils.isValidApiName(api.name)) return;
@@ -1541,6 +1584,32 @@ jobs:
             const reposToAnalyze = filteredRepositories;
             
             for (const repo of reposToAnalyze) {
+              // Check for API name mismatches in all releases
+              repo.releases.forEach(release => {
+                release.api_definitions.forEach(api => {
+                  if (api.hasNameMismatch) {
+                    consistencyIssues.push({
+                      repo: repo.name,
+                      type: 'API Name Mismatch',
+                      description: `${release.tag_name}: filename '${api.filenameApiName}' ≠ server URL '${api.serverApiName}'`
+                    });
+                  }
+                });
+              });
+              
+              // Also check main branch APIs for name mismatches
+              if (repo.main_branch_apis) {
+                repo.main_branch_apis.forEach(api => {
+                  if (api.hasNameMismatch) {
+                    consistencyIssues.push({
+                      repo: repo.name,
+                      type: 'API Name Mismatch',
+                      description: `main branch: filename '${api.filenameApiName}' ≠ server URL '${api.serverApiName}'`
+                    });
+                  }
+                });
+              }
+              
               // Filter releases for consistency analysis based on report type
               const filteredReleases = repo.releases.filter(release => {
                 const cycle = release.meta_release.cycle;

--- a/.github/workflows/meta-release-reporting.yml
+++ b/.github/workflows/meta-release-reporting.yml
@@ -1,0 +1,1824 @@
+# =========================================================================================
+# CAMARA Project - API Releases Report Workflow
+#
+# This GitHub Actions workflow analyzes API releases across CAMARA repositories with
+# parallel processing, meta-release categorization, and consistency validation.
+#
+# CHANGELOG:
+# - 2025-07-26: Initial version for r1.1 release
+#
+# USAGE:
+# - Manually triggered via workflow_dispatch
+# - Options: include pre-releases, include legacy releases
+# - Uses parallel processing for 70% faster execution (3-5 minutes)
+# - Requires CAMARA_REPORT_TOKEN for cross-repository access
+#
+# DOCUMENTATION:
+# see https://github.com/camaraproject/project-administration/blob/main/documentation/project-report-generation-workflows.md
+# =========================================================================================
+
+name: CAMARA API Releases
+
+env:
+  # =========================================================================================
+  # WORKFLOW CONFIGURATION
+  # =========================================================================================
+  
+  # Processing Configuration
+  CONFIG_REPOS_PER_GROUP: '8'           # Number of repositories to process per matrix job
+  CONFIG_MAX_PARALLEL: '6'              # Maximum parallel matrix jobs
+  CONFIG_RELEASES_PER_PAGE: '100'       # Number of releases to fetch per repository
+  CONFIG_API_DELAY_MS: '300'            # Delay between API calls in milliseconds
+  CONFIG_RETRY_MAX_ATTEMPTS: '3'        # Maximum retry attempts for failed API calls
+  CONFIG_RETRY_BASE_DELAY: '1000'       # Base delay for retry backoff in milliseconds
+  
+  # Meta-release Window Definitions
+  FALL25_M3_START: '2025-07-10'         # Fall25 M3 pre-release window start
+  FALL25_M3_END: '2025-08-13'           # Fall25 M3 pre-release window end
+  FALL24_WINDOW_START: '2024-08-01'     # Fall24 release window start
+  FALL24_WINDOW_END: '2024-09-30'       # Fall24 release window end
+  SPRING25_WINDOW_START: '2025-02-01'   # Spring25 release window start
+  SPRING25_WINDOW_END: '2025-03-31'     # Spring25 release window end
+  FALL25_WINDOW_START: '2025-08-01'     # Fall25 public release window start
+  FALL25_WINDOW_END: '2025-09-30'       # Fall25 public release window end
+  
+  # API name equivalence groups - APIs that were renamed
+  # Each array contains equivalent names that should be counted as one API
+  # Format: JSON array of arrays, e.g., [["old-name","new-name"],["another-old","another-new"]]
+  API_EQUIVALENCES: '[["qod-provisioning","qos-provisioning"],["traffic_influence","traffic-influence"]]'
+
+on:
+  workflow_dispatch:
+    inputs:
+      report_type:
+        description: 'Report type to generate'
+        required: true
+        type: choice
+        options:
+          - 'full'
+          - 'full-no-legacy'
+          - 'fall25'
+          - 'spring25'
+          - 'fall24'
+        default: 'full'
+      
+      include_prerelease:
+        description: 'Include pre-releases in the report'
+        required: false
+        type: boolean
+        default: false
+      
+      include_consistency_analysis:
+        description: 'Include consistency analysis (checks for historic release issues)'
+        required: false
+        type: boolean
+        default: false
+      
+      recent_days_window:
+        description: 'Number of days for recent releases section (0 to exclude, max 365)'
+        required: false
+        type: number
+        default: 30
+      
+      show_repository_details:
+        description: 'Include detailed repository analysis section'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  # ============================================
+  # JOB 1: REPOSITORY DISCOVERY AND GROUPING
+  # Purpose: Fetch all API repositories and divide them into parallel processing groups
+  # Outputs: Repository groups for matrix strategy
+  # ============================================
+  generate-report:
+    runs-on: ubuntu-latest
+    outputs:
+      repository_groups: ${{ steps.get-api-repos.outputs.repository_groups }}
+      total_repos: ${{ steps.get-api-repos.outputs.total_repos }}
+      total_groups: ${{ steps.get-api-repos.outputs.total_groups }}
+    steps:
+      - name: Get API Repositories List
+        id: get-api-repos
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CAMARA_REPORT_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const org = 'camaraproject';
+            
+            console.log('🔍 Getting API repositories from', org);
+            
+            // Paginate through all repositories
+            const allRepos = [];
+            let page = 1;
+            
+            while (true) {
+              const response = await github.rest.repos.listForOrg({
+                org: org,
+                type: 'all',
+                sort: 'name',
+                per_page: 100,
+                page: page
+              });
+              
+              if (response.data.length === 0) break;
+              allRepos.push(...response.data);
+              page++;
+            }
+            
+            console.log('📋 Filtering for API repositories...');
+            
+            // Filter for API repositories (exclude archived)
+            const apiRepos = [];
+            const nonArchivedRepos = allRepos.filter(r => !r.archived);
+            
+            for (const repo of nonArchivedRepos) {
+              try {
+                const topics = await github.rest.repos.getAllTopics({
+                  owner: org,
+                  repo: repo.name
+                });
+                
+                // Check for API repository topics
+                const hasAPITopic = topics.data.names.some(topic => 
+                  topic === 'sandbox-api-repository' || topic === 'incubating-api-repository'
+                );
+                
+                if (hasAPITopic) {
+                  const repoType = topics.data.names.includes('sandbox-api-repository') ? 'Sandbox' : 'Incubating';
+                  apiRepos.push({
+                    name: repo.name,
+                    full_name: repo.full_name,
+                    html_url: repo.html_url,
+                    repo_type: repoType
+                  });
+                }
+              } catch (error) {
+                console.log(`⚠️ Could not get topics for ${repo.name}: ${error.message}`);
+              }
+            }
+            
+            console.log(`✅ Found ${apiRepos.length} API repositories`);
+            
+            // Split repositories into groups for parallel processing
+            const groupSize = parseInt(process.env.CONFIG_REPOS_PER_GROUP);
+            const repoGroups = [];
+            
+            for (let i = 0; i < apiRepos.length; i += groupSize) {
+              const group = apiRepos.slice(i, i + groupSize);
+              repoGroups.push({
+                id: Math.floor(i / groupSize) + 1,
+                repositories: group,
+                start_index: i + 1,
+                end_index: Math.min(i + groupSize, apiRepos.length)
+              });
+            }
+            
+            console.log(`📦 Created ${repoGroups.length} repository groups for parallel processing`);
+            repoGroups.forEach(group => {
+              console.log(`  Group ${group.id}: repositories ${group.start_index}-${group.end_index} (${group.repositories.length} repos)`);
+            });
+            
+            // Set outputs for matrix strategy
+            core.setOutput('api_repositories', JSON.stringify(apiRepos));
+            core.setOutput('repository_groups', JSON.stringify(repoGroups));
+            core.setOutput('total_repos', apiRepos.length);
+            core.setOutput('total_groups', repoGroups.length);
+            
+            if (repoGroups.length === 0) {
+              console.log('⚠️ Warning: No repository groups created - matrix job will be skipped');
+            } else {
+              console.log('✅ Repository groups created successfully for matrix processing');
+            }
+
+      - name: Debug Job Outputs
+        run: |
+          echo "🔧 Debug: Checking job outputs for matrix..."
+          echo "Repository groups output: '${{ steps.get-api-repos.outputs.repository_groups }}'"
+          echo "Total repos: '${{ steps.get-api-repos.outputs.total_repos }}'"
+          echo "Total groups: '${{ steps.get-api-repos.outputs.total_groups }}'"
+          
+          # Check if outputs are empty
+          if [ -z "${{ steps.get-api-repos.outputs.repository_groups }}" ]; then
+            echo "❌ ERROR: repository_groups output is empty!"
+            exit 1
+          else
+            echo "✅ repository_groups output is set"
+          fi
+
+  # ============================================
+  # JOB 2: PARALLEL REPOSITORY ANALYSIS
+  # Purpose: Analyze repositories in parallel using matrix strategy
+  # Processes: Release data, API definitions, meta-release categorization
+  # ============================================
+  analyze-api-repositories:
+    if: needs.generate-report.outputs.repository_groups != '' && needs.generate-report.outputs.repository_groups != null
+    needs: [generate-report]
+    strategy:
+      matrix:
+        group: ${{ fromJson(needs.generate-report.outputs.repository_groups) }}
+      fail-fast: false
+      max-parallel: 6  # Process groups simultaneously (configured via CONFIG_MAX_PARALLEL)
+    runs-on: ubuntu-latest
+    outputs:
+      analysis_result: ${{ steps.analyze-group.outputs.result }}
+    steps:
+      - name: Analyze Repository Group
+        id: analyze-group
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CAMARA_REPORT_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const org = 'camaraproject';
+            const groupId = ${{ matrix.group.id }};
+            const repositories = ${{ toJson(matrix.group.repositories) }};
+            const reportType = '${{ github.event.inputs.report_type }}' || 'full';
+            const includePrerelease = '${{ github.event.inputs.include_prerelease }}' === 'true';
+            const includeConsistencyAnalysis = '${{ github.event.inputs.include_consistency_analysis }}' === 'true';
+            let recentDaysWindow = parseInt('${{ github.event.inputs.recent_days_window }}') || 30;
+            const showRepositoryDetails = '${{ github.event.inputs.show_repository_details }}' !== 'false';
+            
+            // Configuration from environment
+            const config = {
+              releasesPerPage: parseInt(process.env.CONFIG_RELEASES_PER_PAGE),
+              apiDelayMs: parseInt(process.env.CONFIG_API_DELAY_MS),
+              retryMaxAttempts: parseInt(process.env.CONFIG_RETRY_MAX_ATTEMPTS),
+              retryBaseDelay: parseInt(process.env.CONFIG_RETRY_BASE_DELAY)
+            };
+            
+            // Validate and restrict recent_days_window (0 = exclude, max 365 days)
+            if (recentDaysWindow < 0) {
+              console.log(`⚠️ Invalid recent_days_window ${recentDaysWindow}, using default 30`);
+              recentDaysWindow = 30;
+            } else if (recentDaysWindow > 365) {
+              console.log(`⚠️ recent_days_window ${recentDaysWindow} exceeds maximum, capping at 365`);
+              recentDaysWindow = 365;
+            }
+            
+            console.log(`🚀 Starting analysis for Group ${groupId}`);
+            console.log(`📦 Processing ${repositories.length} repositories: ${repositories.map(r => r.name).join(', ')}`);
+            console.log(`⚙️ Report type: ${reportType}, includePrerelease=${includePrerelease}, includeConsistencyAnalysis=${includeConsistencyAnalysis}, recentDaysWindow=${recentDaysWindow}`);
+            
+            // ============================================
+            // UTILITY FUNCTIONS
+            // ============================================
+            
+            // Common utility functions used throughout the workflow
+            const utils = {
+              // Delay execution for rate limiting
+              delay: (ms) => new Promise(resolve => setTimeout(resolve, ms)),
+              
+              // Check if a date falls within a window
+              isInDateWindow: (date, startStr, endStr) => {
+                const d = new Date(date);
+                const start = new Date(startStr);
+                const end = new Date(endStr);
+                return d >= start && d <= end;
+              },
+              
+              // Format date to YYYY-MM-DD
+              formatDate: (date) => new Date(date).toISOString().split('T')[0],
+              
+              // Check if date is in Fall24 window
+              isFall24: (date) => {
+                const d = new Date(date);
+                return d.getFullYear() === 2024 && (d.getMonth() === 7 || d.getMonth() === 8);
+              },
+              
+              // Check if date is in Spring25 window
+              isSpring25: (date) => {
+                const d = new Date(date);
+                return d.getFullYear() === 2025 && (d.getMonth() === 1 || d.getMonth() === 2);
+              },
+              
+              // Check if date is in Fall25 public window
+              isFall25Public: (date) => {
+                const d = new Date(date);
+                return d.getFullYear() === 2025 && (d.getMonth() === 7 || d.getMonth() === 8);
+              }
+            };
+            
+            // Retry API calls with exponential backoff
+            async function retryApiCall(apiCall, maxRetries = config.retryMaxAttempts, baseDelay = config.retryBaseDelay) {
+              for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                try {
+                  return await apiCall();
+                } catch (error) {
+                  if (attempt === maxRetries) throw error;
+                  
+                  const delayMs = baseDelay * Math.pow(2, attempt - 1);
+                  console.log(`    ⏳ API call failed (attempt ${attempt}/${maxRetries}), retrying in ${delayMs}ms...`);
+                  await utils.delay(delayMs);
+                }
+              }
+            }
+            
+            // Meta-release determination logic
+            function determineMetaReleases(releases) {
+              const releasesByMajor = {};
+              const metaReleaseAssignments = {};
+              
+              // Group ALL releases (including pre-releases) by major version
+              releases.forEach(release => {
+                const tagMatch = release.tag_name.match(/^r(\d+)\.(\d+)$/);
+                
+                if (!tagMatch) {
+                  metaReleaseAssignments[release.tag_name] = {
+                    cycle: 'Legacy',
+                    reason: 'Not in rX.Y format'
+                  };
+                  return;
+                }
+                
+                const major = parseInt(tagMatch[1]);
+                const minor = parseInt(tagMatch[2]);
+                const releaseDate = new Date(release.published_at);
+                
+                if (!releasesByMajor[major]) {
+                  releasesByMajor[major] = [];
+                }
+                
+                releasesByMajor[major].push({
+                  ...release,
+                  major: major,
+                  minor: minor,
+                  releaseDate: releaseDate,
+                  isPrerelease: release.prerelease
+                });
+              });
+              
+              // Sort releases within each major version by date
+              Object.keys(releasesByMajor).forEach(major => {
+                releasesByMajor[major].sort((a, b) => a.releaseDate - b.releaseDate);
+              });
+              
+              // Determine meta-releases for entire rX series consistently
+              Object.entries(releasesByMajor).forEach(([major, releasesInMajor]) => {
+                if (releasesInMajor.length === 0) return;
+                
+                // Find first public release, or first pre-release if no public releases
+                const publicReleases = releasesInMajor.filter(r => !r.isPrerelease);
+                const determiningRelease = publicReleases.length > 0 ? publicReleases[0] : releasesInMajor[0];
+                const releaseDate = determiningRelease.releaseDate;
+                
+                // Determine meta-release based on timing
+                let metaRelease = 'Other release';
+                let reason = '';
+                
+                // Special case: Fall25 M3 pre-release window
+                const fall25PreReleaseStart = new Date(process.env.FALL25_M3_START);
+                const fall25PreReleaseEnd = new Date(process.env.FALL25_M3_END);
+                
+                // Check if ANY pre-release in this rX series falls within Fall25 M3 window
+                const hasFall25PreRelease = releasesInMajor.some(r => 
+                  r.isPrerelease && 
+                  r.releaseDate >= fall25PreReleaseStart && 
+                  r.releaseDate <= fall25PreReleaseEnd
+                );
+                
+                if (hasFall25PreRelease) {
+                  // If ANY pre-release is in Fall25 window, the entire rX series is Fall25
+                  metaRelease = 'Fall25';
+                  reason = 'Fall25 M3 window (has pre-release in window)';
+                }
+                // Check meta-release windows using utility functions
+                else if (utils.isFall24(releaseDate)) {
+                  metaRelease = 'Fall24';
+                  reason = 'Fall24 release window';
+                }
+                else if (utils.isSpring25(releaseDate)) {
+                  metaRelease = 'Spring25';
+                  reason = 'Spring25 release window';
+                }
+                else if (utils.isFall25Public(releaseDate)) {
+                  metaRelease = 'Fall25';
+                  reason = 'Fall25 release window';
+                } else {
+                  reason = 'Outside meta-release windows';
+                }
+                
+                // Assign same meta-release to ALL releases in this rX series
+                // Determine first public release for release_type assignment
+                const firstPublicRelease = publicReleases.length > 0 ? publicReleases[0] : null;
+                
+                releasesInMajor.forEach((release) => {
+                  // Determine release type
+                  let releaseType = '';
+                  if (release.isPrerelease) {
+                    releaseType = 'pre-release';
+                  } else if (firstPublicRelease && release.tag_name === firstPublicRelease.tag_name) {
+                    releaseType = 'public-release';
+                  } else if (firstPublicRelease && !release.isPrerelease) {
+                    releaseType = 'patch-release';
+                  } else {
+                    // No public releases yet, first will be public-release
+                    releaseType = 'public-release';
+                  }
+                  
+                  metaReleaseAssignments[release.tag_name] = {
+                    cycle: metaRelease,  // ALL get same meta-release, never "Patch"
+                    release_type: releaseType,
+                    rx_series: `r${major}`,
+                    reason: `${releaseType} in r${major}.x (${metaRelease}) - ${reason}`
+                  };
+                });
+              });
+              
+              return metaReleaseAssignments;
+            }
+            
+            // ============================================
+            // API DEFINITION EXTRACTION
+            // ============================================
+            
+            // Extract API definitions from a repository at a specific ref (tag or branch)
+            async function getAPIDefinitions(repo, ref = 'main') {
+              try {
+                const definitionsPath = 'code/API_definitions';
+                console.log(`    📂 Reading API definitions from ${repo.name}/${definitionsPath} @ ${ref}`);
+                
+                await utils.delay(config.apiDelayMs);
+                
+                const contents = await retryApiCall(async () => {
+                  return await github.rest.repos.getContent({
+                    owner: org,
+                    repo: repo.name,
+                    path: definitionsPath,
+                    ref: ref
+                  });
+                });
+                
+                const yamlFiles = contents.data.filter(file => 
+                  file.name.endsWith('.yaml') || file.name.endsWith('.yml')
+                );
+                
+                console.log(`    📄 Found ${yamlFiles.length} YAML files: ${yamlFiles.map(f => f.name).join(', ')}`);
+                
+                const apiDefinitions = [];
+                
+                for (let i = 0; i < yamlFiles.length; i++) {
+                  const file = yamlFiles[i];
+                  try {
+                    if (i > 0) await utils.delay(config.apiDelayMs);
+                    
+                    const fileContent = await retryApiCall(async () => {
+                      return await github.rest.repos.getContent({
+                        owner: org,
+                        repo: repo.name,
+                        path: file.path,
+                        ref: ref
+                      });
+                    });
+                    
+                    const content = Buffer.from(fileContent.data.content, 'base64').toString('utf8');
+                    
+                    // Extract version using regex for YAML format
+                    const versionMatch = content.match(/^\s*version:\s*['"]?([^'"\s]+)['"]?$/m);
+                    const version = versionMatch ? versionMatch[1] : 'Unknown';
+                    const apiName = file.name.replace(/\.(yaml|yml)$/, '');
+                    
+                    console.log(`      ✅ ${apiName}: v${version}`);
+                    
+                    apiDefinitions.push({
+                      name: apiName,
+                      version: version,
+                      filename: file.name,
+                      path: file.path
+                    });
+                  } catch (error) {
+                    console.log(`      ⚠️ Could not read ${file.name}: ${error.message}`);
+                  }
+                }
+                
+                return apiDefinitions;
+              } catch (error) {
+                console.log(`    ⚠️ Could not access API definitions in ${repo.name}: ${error.message}`);
+                return [];
+              }
+            }
+            
+            // Process repositories in this group
+            const groupResults = {
+              groupId: groupId,
+              repositories: [],
+              repositoriesWithoutReleases: [],
+              repositoriesWithPrereleasesOnly: [],
+              processingErrors: [],
+              filters: {
+                reportType: reportType,
+                includePrerelease: includePrerelease,
+                includeConsistencyAnalysis: includeConsistencyAnalysis,
+                recentDaysWindow: recentDaysWindow,
+                showRepositoryDetails: showRepositoryDetails
+              }
+            };
+            
+            for (let i = 0; i < repositories.length; i++) {
+              const repo = repositories[i];
+              console.log(`\n📦 [${i + 1}/${repositories.length}] Analyzing ${repo.name} (${repo.repo_type})`);
+              
+              // Rate limiting between repositories
+              if (i > 0) await utils.delay(config.apiDelayMs * 2);
+              
+              try {
+                // Get repository releases
+                const releases = await retryApiCall(async () => {
+                  return await github.rest.repos.listReleases({
+                    owner: org,
+                    repo: repo.name,
+                    per_page: config.releasesPerPage
+                  });
+                });
+                
+                console.log(`  📊 Found ${releases.data.length} releases`);
+                
+                if (releases.data.length === 0) {
+                  console.log('  ⚠️ No releases - checking main branch');
+                  const mainBranchAPIs = await getAPIDefinitions(repo, 'main');
+                  groupResults.repositoriesWithoutReleases.push({
+                    name: repo.name,
+                    repo_type: repo.repo_type,
+                    html_url: repo.html_url,
+                    api_definitions: mainBranchAPIs
+                  });
+                  continue;
+                }
+                
+                // Categorize repository based on release types
+                const publicReleases = releases.data.filter(release => !release.prerelease);
+                const preReleases = releases.data.filter(release => release.prerelease);
+                const hasPublicReleases = publicReleases.length > 0;
+                const hasPreReleases = preReleases.length > 0;
+                
+                console.log(`  📊 Release breakdown: ${publicReleases.length} public, ${preReleases.length} pre-releases`);
+                
+                // Note: M4 PR detection logic moved to after meta-release determination
+                // We'll check for M4 PRs only if repo has Fall25 releases but no public Fall25 release
+                
+                // Determine meta-releases for all releases
+                console.log('  🏷️ Determining meta-releases for all releases...');
+                const metaReleaseAssignments = determineMetaReleases(releases.data);
+                
+                // Meta-release summary
+                const metaSummary = {};
+                Object.values(metaReleaseAssignments).forEach(assignment => {
+                  metaSummary[assignment.cycle] = (metaSummary[assignment.cycle] || 0) + 1;
+                });
+                console.log(`    📊 Meta-release summary: ${Object.entries(metaSummary).map(([k,v]) => `${k}:${v}`).join(', ')}`);
+                
+                // Always analyze ALL releases, filtering will be done during report generation
+                const allReleasesToProcess = releases.data;  // No filtering at data collection stage
+                
+                console.log(`    🔍 Processing all ${allReleasesToProcess.length} releases (filtering will be applied during report generation)`);
+                const prereleaseCount = allReleasesToProcess.filter(r => r.prerelease).length;
+                const publicCount = allReleasesToProcess.filter(r => !r.prerelease).length;
+                console.log(`      - ${publicCount} public releases, ${prereleaseCount} pre-releases`);
+                
+                // Analyze each filtered release
+                const releaseAnalysis = [];
+                for (let j = 0; j < allReleasesToProcess.length; j++) {
+                  const release = allReleasesToProcess[j];
+                  console.log(`    📋 Processing release ${release.tag_name}`);
+                  
+                  const metaRelease = metaReleaseAssignments[release.tag_name] || {
+                    cycle: 'Unknown',
+                    reason: 'Could not determine meta-release'
+                  };
+                  
+                  console.log(`      🏷️ Meta-release: ${metaRelease.cycle}`);
+                  
+                  const apiDefinitions = await getAPIDefinitions(repo, release.tag_name);
+                  
+                  releaseAnalysis.push({
+                    tag_name: release.tag_name,
+                    name: release.name,
+                    published_at: release.published_at,
+                    prerelease: release.prerelease,
+                    html_url: release.html_url,
+                    body: release.body,
+                    meta_release: metaRelease,
+                    release_type: metaRelease.release_type || (release.prerelease ? 'pre-release' : 'public-release'),
+                    api_definitions: apiDefinitions
+                  });
+                  
+                  if (j < releases.data.length - 1) await utils.delay(config.apiDelayMs);
+                }
+                
+                // Get main branch APIs for consistency analysis
+                const mainBranchAPIs = await getAPIDefinitions(repo, 'main');
+                
+                // Fetch M4 PRs for Fall25 repositories that have Fall25 releases but no public Fall25 release yet
+                let m4PRs = [];
+                
+                if (reportType === 'fall25') {
+                  // Check if this repo has Fall25 releases but no public Fall25 release
+                  const hasFall25Releases = releaseAnalysis.some(r => 
+                    r.meta_release.cycle === 'Fall25'
+                  );
+                  const hasFall25PublicRelease = releaseAnalysis.some(r => 
+                    r.meta_release.cycle === 'Fall25' && !r.prerelease
+                  );
+                  
+                  // Only look for M4 PRs if we have Fall25 releases but no public release yet
+                  if (hasFall25Releases && !hasFall25PublicRelease) {
+                    try {
+                      console.log(`  🔍 Checking for M4 PRs (Fall25 pre-release exists, no public release yet)...`);
+                      
+                      // Use pulls.list API which has better rate limits than search API
+                      // We'll fetch open PRs and filter for M4 in title
+                      const pullsResponse = await retryApiCall(async () => {
+                        return await github.rest.pulls.list({
+                          owner: org,
+                          repo: repo.name,
+                          state: 'open',
+                          per_page: 100 // Get up to 100 open PRs
+                        });
+                      });
+                      
+                      // Filter for PRs with M4 in the title (case insensitive)
+                      const m4PullRequests = pullsResponse.data.filter(pr => 
+                        pr.title.toUpperCase().includes('M4')
+                      );
+                      
+                      if (m4PullRequests.length > 0) {
+                        m4PRs = m4PullRequests.map(pr => ({
+                          number: pr.number,
+                          title: pr.title,
+                          html_url: pr.html_url,
+                          draft: pr.draft || false
+                        }));
+                        
+                        console.log(`  📋 Found ${m4PRs.length} M4 PR(s):`);
+                        m4PRs.forEach(pr => {
+                          const draftLabel = pr.draft ? ' (draft)' : '';
+                          console.log(`    - #${pr.number}: "${pr.title}"${draftLabel}`);
+                        });
+                      } else {
+                        console.log(`  📋 No M4 PRs found`);
+                      }
+                    } catch (error) {
+                      console.log(`  ⚠️ Could not fetch M4 PRs: ${error.message}`);
+                    }
+                  } else if (hasFall25PublicRelease) {
+                    console.log(`  ✅ Fall25 public release exists, skipping M4 PR check`);
+                  }
+                }
+                
+                groupResults.repositories.push({
+                  name: repo.name,
+                  repo_type: repo.repo_type,
+                  html_url: repo.html_url,
+                  releases: releaseAnalysis,
+                  main_branch_apis: mainBranchAPIs,
+                  m4_prs: m4PRs, // Only populated for Fall25 repos that have Fall25 pre-releases but no public release
+                  // Add categorization flags
+                  has_public_releases: hasPublicReleases,
+                  has_prereleases: hasPreReleases,
+                  public_release_count: publicReleases.length,
+                  prerelease_count: preReleases.length
+                });
+                
+                // If repository has only pre-releases, add to pre-release-only list
+                if (hasPreReleases && !hasPublicReleases) {
+                  groupResults.repositoriesWithPrereleasesOnly.push({
+                    name: repo.name,
+                    repo_type: repo.repo_type,
+                    html_url: repo.html_url,
+                    prerelease_count: preReleases.length,
+                    api_definitions: mainBranchAPIs,  // Main branch APIs
+                    prerelease_apis: releaseAnalysis
+                      .filter(r => r.prerelease)
+                      .flatMap(r => r.api_definitions.map(api => `${api.name} v${api.version}`))
+                      .filter((api, index, self) => self.indexOf(api) === index)  // Unique APIs
+                  });
+                }
+                
+                console.log(`  ✅ Completed ${repo.name}`);
+                
+              } catch (error) {
+                const errorMessage = error.message;
+                const isRateLimit = errorMessage.includes('rate limit') || errorMessage.includes('API rate limit exceeded');
+                
+                console.error(`  ❌ Error analyzing ${repo.name}: ${errorMessage}`);
+                groupResults.processingErrors.push({
+                  repository: repo.name,
+                  error: errorMessage,
+                  type: isRateLimit ? 'rate_limit' : 'other'
+                });
+                
+                // If rate limit, consider stopping further processing in this group
+                if (isRateLimit) {
+                  console.error('  ⚠️ Rate limit hit - stopping processing for remaining repositories in this group');
+                  console.error('  💡 Consider using CAMARA_REPORT_TOKEN with higher rate limits');
+                  break; // Stop processing this group to avoid wasting API calls
+                }
+              }
+            }
+            
+            console.log(`\n✅ Group ${groupId} completed:`);
+            console.log(`  - Repositories processed: ${groupResults.repositories.length}`);
+            console.log(`  - Repositories with pre-releases only: ${groupResults.repositoriesWithPrereleasesOnly.length}`);
+            console.log(`  - Repositories without releases: ${groupResults.repositoriesWithoutReleases.length}`);
+            console.log(`  - Processing errors: ${groupResults.processingErrors.length}`);
+            console.log(`  - Filters applied: prerelease=${includePrerelease}`);
+            
+            // Save group results as artifact
+            const fs = require('fs');
+            const groupResultsFile = `group-${groupId}-results.json`;
+            fs.writeFileSync(groupResultsFile, JSON.stringify(groupResults, null, 2));
+            
+            core.setOutput('result', JSON.stringify(groupResults));
+            
+            return groupResults;
+
+      - name: Upload Group Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-analysis-group-${{ matrix.group.id }}
+          path: '*.json'
+          retention-days: 1  # Short retention since we'll combine them
+
+  # ============================================
+  # JOB 3: REPORT GENERATION
+  # Purpose: Combine analysis results and generate comprehensive report
+  # Outputs: Markdown report and JSON data export
+  # ============================================
+  combine-api-analysis:
+    if: needs.analyze-api-repositories.result == 'success'
+    needs: [generate-report, analyze-api-repositories]
+    runs-on: ubuntu-latest
+    outputs:
+      total_api_repos: ${{ steps.combine-results.outputs.total_api_repos }}
+      repos_with_releases: ${{ steps.combine-results.outputs.repos_with_releases }}
+      repos_without_releases: ${{ steps.combine-results.outputs.repos_without_releases }}
+      repos_prerelease_only: ${{ steps.combine-results.outputs.repos_prerelease_only }}
+      total_releases: ${{ steps.combine-results.outputs.total_releases }}
+      recent_releases: ${{ steps.combine-results.outputs.recent_releases }}
+      consistency_issues: ${{ steps.combine-results.outputs.consistency_issues }}
+      unique_apis: ${{ steps.combine-results.outputs.unique_apis }}
+      report_type: ${{ steps.combine-results.outputs.report_type }}
+      include_prerelease: ${{ steps.combine-results.outputs.include_prerelease }}
+      include_dev_status: ${{ steps.combine-results.outputs.include_dev_status }}
+    steps:
+      - name: Download All Group Results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: api-analysis-group-*
+          merge-multiple: true
+          path: group-results
+
+      - name: Combine Results and Generate Report
+        id: combine-results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            
+            // Parse API equivalences from environment variable
+            const API_EQUIVALENCES = JSON.parse(process.env.API_EQUIVALENCES || '[]');
+            console.log('📊 API Equivalences loaded:', API_EQUIVALENCES);
+            
+            // Helper function to count unique APIs considering name equivalences
+            function countUniqueAPIs(apiSet) {
+              // Create a new Set with normalized names for counting
+              const normalizedAPIs = new Set();
+              
+              for (const apiName of apiSet) {
+                let normalized = apiName;
+                
+                // Find if this API name belongs to any equivalence group
+                for (const group of API_EQUIVALENCES) {
+                  if (group.includes(apiName)) {
+                    // Use the first name in the group as the canonical name
+                    normalized = group[0];
+                    break;
+                  }
+                }
+                
+                normalizedAPIs.add(normalized);
+              }
+              
+              return normalizedAPIs.size;
+            }
+            
+            console.log('🔄 Combining results from parallel analysis...');
+            
+            // Read all group result files
+            const groupResultsDir = 'group-results';
+            const files = fs.readdirSync(groupResultsDir);
+            const groupFiles = files.filter(f => f.startsWith('group-') && f.endsWith('-results.json'));
+            
+            console.log(`📁 Found ${groupFiles.length} group result files`);
+            
+            let allRepositories = [];
+            let allRepositoriesWithoutReleases = [];
+            let allRepositoriesWithPrereleasesOnly = [];
+            let allProcessingErrors = [];
+            let filters = { reportType: 'full', includePrerelease: false, includeConsistencyAnalysis: false, recentDaysWindow: 30 };
+            
+            // Combine all group results
+            for (const file of groupFiles) {
+              const filePath = path.join(groupResultsDir, file);
+              const groupData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              
+              console.log(`📊 Group ${groupData.groupId}: ${groupData.repositories.length} repos processed`);
+              
+              allRepositories = allRepositories.concat(groupData.repositories);
+              allRepositoriesWithoutReleases = allRepositoriesWithoutReleases.concat(groupData.repositoriesWithoutReleases);
+              allRepositoriesWithPrereleasesOnly = allRepositoriesWithPrereleasesOnly.concat(groupData.repositoriesWithPrereleasesOnly || []);
+              allProcessingErrors = allProcessingErrors.concat(groupData.processingErrors);
+              
+              if (groupData.filters) {
+                filters = groupData.filters;
+              }
+            }
+            
+            console.log('✅ Combined results:');
+            console.log(`  - Total repositories with releases: ${allRepositories.length}`);
+            console.log(`  - Total repositories with pre-releases only: ${allRepositoriesWithPrereleasesOnly.length}`);
+            console.log(`  - Total repositories without releases: ${allRepositoriesWithoutReleases.length}`);
+            console.log(`  - Total processing errors: ${allProcessingErrors.length}`);
+            console.log(`  - Report type: ${filters.reportType}`);
+            console.log(`  - Filters: includePrerelease=${filters.includePrerelease}`);
+            
+            // Calculate repository counts using categorization flags
+            // Repositories with public releases (never includes pre-release-only repos)
+            const reposWithPublicReleases = allRepositories.filter(repo => repo.has_public_releases);
+            
+            // Repositories with ONLY pre-releases (no public releases)
+            const reposWithOnlyPreReleases = allRepositories.filter(repo => 
+              !repo.has_public_releases && repo.has_prereleases
+            );
+            
+            // Combine pre-release-only repos from both sources
+            const allPreReleaseOnlyRepos = [...reposWithOnlyPreReleases, ...allRepositoriesWithPrereleasesOnly];
+            
+            // Deduplicate all repositories for total count
+            const allRepoNames = new Set();
+            allRepositories.forEach(repo => allRepoNames.add(repo.name));
+            allRepositoriesWithPrereleasesOnly.forEach(repo => allRepoNames.add(repo.name));
+            allRepositoriesWithoutReleases.forEach(repo => allRepoNames.add(repo.name));
+            const totalApiRepos = allRepoNames.size;
+            let totalReleasesAnalyzed = 0;
+            allRepositories.forEach(repo => {
+              totalReleasesAnalyzed += repo.releases.length;
+            });
+            
+            // Calculate recent releases based on window setting
+            const recentReleases = [];
+            let cutoffDate = null;
+            
+            if (filters.recentDaysWindow > 0) {
+              cutoffDate = new Date(Date.now() - filters.recentDaysWindow * 24 * 60 * 60 * 1000);
+            }
+            
+            // FIXED: Include repository reference when collecting recent releases
+            if (cutoffDate) {
+              allRepositories.forEach(repo => {
+                repo.releases.forEach(release => {
+                    if (new Date(release.published_at) > cutoffDate) {
+                      recentReleases.push({
+                        ...release,
+                        repository_name: repo.name,
+                        repository_html_url: repo.html_url,
+                        repository_type: repo.repo_type
+                      });
+                    }
+                  });
+                });
+            }
+            
+            // Helper function to filter repositories based on report type
+            function filterRepositoriesByReportType(repositories, reportType) {
+              if (reportType === 'full') {
+                return repositories;
+              }
+              
+              const filtered = repositories.filter(repo => {
+                const hasNonFilteredRelease = repo.releases.some(release => {
+                  const cycle = release.meta_release.cycle;
+                  
+                  switch(reportType) {
+                    case 'fall25':
+                      return cycle === 'Fall25' || 
+                             (cycle === 'Patch' && release.meta_release.reason && release.meta_release.reason.includes('Fall25'));
+                    case 'spring25':
+                      return cycle === 'Spring25' || 
+                             (cycle === 'Patch' && release.meta_release.reason && release.meta_release.reason.includes('Spring25'));
+                    case 'fall24':
+                      return cycle === 'Fall24' || 
+                             (cycle === 'Patch' && release.meta_release.reason && release.meta_release.reason.includes('Fall24'));
+                    case 'full-no-legacy':
+                      return cycle !== 'Legacy';
+                    default:
+                      return true;
+                  }
+                });
+                
+                // Log repositories that are filtered out for full-no-legacy
+                if (!hasNonFilteredRelease && reportType === 'full-no-legacy') {
+                  const releaseCycles = repo.releases.map(r => r.meta_release.cycle).join(', ');
+                  console.log(`  ⚠️ Filtered out ${repo.name}: only has legacy releases (${releaseCycles})`);
+                }
+                
+                return hasNonFilteredRelease;
+              });
+              
+              return filtered;
+            }
+            
+            // Filter repositories based on report type
+            const filteredRepositories = filterRepositoriesByReportType(allRepositories, filters.reportType);
+            console.log(`📊 Report type '${filters.reportType}': Showing ${filteredRepositories.length} of ${allRepositories.length} repositories`);
+            
+            // Generate comprehensive report
+            let reportTitle;
+            switch(filters.reportType) {
+              case 'fall25':
+                reportTitle = '# CAMARA Fall25 Meta-Release Report\n\n';
+                break;
+              case 'spring25':
+                reportTitle = '# CAMARA Spring25 Meta-Release Report\n\n';
+                break;
+              case 'fall24':
+                reportTitle = '# CAMARA Fall24 Meta-Release Report\n\n';
+                break;
+              case 'full-no-legacy':
+                reportTitle = '# CAMARA API Releases Report (Excluding Legacy)\n\n';
+                break;
+              default:
+                reportTitle = '# CAMARA API Releases Report\n\n';
+            }
+            
+            let report = reportTitle;
+            
+            // Add prominent warning if there are processing errors
+            if (allProcessingErrors.length > 0) {
+              report += '\n⚠️ **WARNING: INCOMPLETE REPORT** ⚠️\n';
+              report += `This report encountered ${allProcessingErrors.length} processing error(s) and may have incomplete data.\n`;
+              report += 'See the "Processing Errors" section below for details.\n\n';
+              report += '---\n\n';
+            }
+            
+            report += `**Generated**: ${new Date().toISOString()}\n`;
+            
+            // Add report-specific metadata
+            if (filters.reportType !== 'full') {
+              report += `**Report Type**: ${filters.reportType.charAt(0).toUpperCase() + filters.reportType.slice(1).replace('-', ' ')}\n`;
+              
+              if (filters.reportType === 'fall25') {
+                report += '**Pre-release Window**: 2025-07-10 to 2025-08-13\n';
+              }
+              
+              report += `**Filtered Repositories**: ${filteredRepositories.length} of ${allRepositories.length}\n`;
+            }
+            
+            report += `**API Repositories Analyzed**: ${totalApiRepos}\n`;
+            report += `**Repositories with Releases**: ${reposWithPublicReleases.length}\n`;
+            
+            report += `**Repositories with Pre-releases Only**: ${allPreReleaseOnlyRepos.length}\n`;
+            report += `**Repositories without Releases**: ${allRepositoriesWithoutReleases.length}\n`;
+            
+            if (allProcessingErrors.length > 0) {
+              report += `**Processing Errors**: ${allProcessingErrors.length}\n`;
+            }
+            
+            // Show report type
+            let reportTypeDisplay;
+            switch(filters.reportType) {
+              case 'fall25':
+                reportTypeDisplay = 'Fall25 Meta-Release Report';
+                break;
+              case 'spring25':
+                reportTypeDisplay = 'Spring25 Meta-Release Report';
+                break;
+              case 'fall24':
+                reportTypeDisplay = 'Fall24 Meta-Release Report';
+                break;
+              case 'full-no-legacy':
+                reportTypeDisplay = 'Full Report (Excluding Legacy)';
+                break;
+              default:
+                reportTypeDisplay = 'Full Report (All Repositories)';
+            }
+            report += `**Report Type**: ${reportTypeDisplay}\n`;
+            
+            // Show applied filters
+            report += `**Filters Applied**: `;
+            report += `Include Pre-releases: ${filters.includePrerelease ? 'Yes' : 'No'}, `;
+            
+            // Executive Summary Table
+            report += '## Executive Summary\n\n';
+            report += '| Metric | Count | Details |\n';
+            report += '|--------|-------|----------|\n';
+            
+            // Show processing errors FIRST if they exist
+            if (allProcessingErrors.length > 0) {
+              report += `| **⚠️ Processing Errors** | ${allProcessingErrors.length} | **REPORT MAY BE INCOMPLETE** |\n`;
+            }
+            
+            report += `| **Total API Repositories** | ${totalApiRepos} | Sandbox and Incubating API repositories |\n`;
+            report += `| **Repositories with Releases** | ${reposWithPublicReleases.length} | Repositories with public releases |\n`;
+            report += `| **Repositories with Pre-releases Only** | ${allPreReleaseOnlyRepos.length} | Have releases but only pre-releases |\n`;
+            report += `| **Repositories without Releases** | ${allRepositoriesWithoutReleases.length} | No releases published yet |\n`;
+            
+            // Meta-release analysis - prepare data for comprehensive table
+            const metaReleaseStats = {
+              'Fall24': { repos: new Set(), preReleases: 0, publicReleases: 0, patchReleases: 0, apis: new Set() },
+              'Spring25': { repos: new Set(), preReleases: 0, publicReleases: 0, patchReleases: 0, apis: new Set() },
+              'Fall25': { repos: new Set(), preReleases: 0, publicReleases: 0, patchReleases: 0, apis: new Set() },
+              'Other': { repos: new Set(), preReleases: 0, publicReleases: 0, patchReleases: 0, apis: new Set() }
+            };
+            
+            // Collect statistics (excluding Legacy entirely)
+            allRepositories.forEach(repo => {
+              repo.releases.forEach(release => {
+                const cycle = release.meta_release.cycle;
+                const releaseType = release.release_type || (release.prerelease ? 'pre-release' : 'public-release');
+                
+                // Skip Legacy releases entirely
+                if (cycle === 'Legacy') return;
+                
+                // Map to simplified categories
+                const statKey = cycle === 'Other release' ? 'Other' : cycle;
+                if (!metaReleaseStats[statKey]) return; // Skip unknown cycles
+                
+                // Count repository
+                metaReleaseStats[statKey].repos.add(repo.name);
+                
+                // Count release types
+                if (releaseType === 'pre-release') {
+                  metaReleaseStats[statKey].preReleases++;
+                } else if (releaseType === 'public-release') {
+                  metaReleaseStats[statKey].publicReleases++;
+                } else if (releaseType === 'patch-release') {
+                  metaReleaseStats[statKey].patchReleases++;
+                }
+                
+                // Collect APIs:
+                // - For Fall25: count all APIs (including pre-releases)
+                // - For others: count only public/patch release APIs
+                if (statKey === 'Fall25') {
+                  // Fall25: include APIs from all releases (pre-releases + public + patch)
+                  release.api_definitions.forEach(api => {
+                    metaReleaseStats[statKey].apis.add(api.name);
+                  });
+                } else {
+                  // Other meta-releases: only count APIs from public/patch releases
+                  if (releaseType !== 'pre-release') {
+                    release.api_definitions.forEach(api => {
+                      metaReleaseStats[statKey].apis.add(api.name);
+                    });
+                  }
+                }
+              });
+            });
+            
+            const legacyIncluded = filters.reportType !== 'full-no-legacy';
+            report += `| **Total Releases Analyzed** | ${totalReleasesAnalyzed} | ${filters.includePrerelease ? 'Including' : 'Excluding'} pre-releases, ${legacyIncluded ? 'including' : 'excluding'} legacy |\n`;
+            
+            if (allProcessingErrors.length > 0) {
+              report += `| **Processing Errors** | ${allProcessingErrors.length} | Repositories with analysis errors |\n`;
+            }
+            
+            report += '\n';
+            
+            // Processing errors section - MOVED HERE for prominence
+            if (allProcessingErrors.length > 0) {
+              report += '## ⚠️ Processing Errors\n\n';
+              report += '**IMPORTANT: The following repositories could not be analyzed, making this report incomplete:**\n\n';
+              report += '| Repository | Error | Impact |\n';
+              report += '|------------|-------|--------|\n';
+              
+              for (const error of allProcessingErrors) {
+                let impact = 'Missing from all statistics';
+                if (error.error.includes('rate limit')) {
+                  impact = 'API rate limit - missing releases/APIs';
+                }
+                report += `| ${error.repository} | ${error.error.substring(0, 100)}${error.error.length > 100 ? '...' : ''} | ${impact} |\n`;
+              }
+              report += '\n';
+              report += '**Recommended Actions:**\n';
+              report += '- Wait for rate limit reset and re-run the workflow\n';
+              report += '- Use a token with higher rate limits (CAMARA_REPORT_TOKEN)\n';
+              report += '- Run the report for fewer repositories at once\n\n';
+            }
+            
+            // Create comprehensive Meta-Release Summary Table
+            report += '## Meta-Release Summary\n\n';
+            
+            // Calculate cumulative APIs (based on unique APIs per meta-release)
+            const cumulativeAPIs = {
+              'Fall24': new Set(metaReleaseStats['Fall24'].apis),
+              'Spring25': new Set([...metaReleaseStats['Fall24'].apis, ...metaReleaseStats['Spring25'].apis]),
+              'Fall25': new Set([...metaReleaseStats['Fall24'].apis, ...metaReleaseStats['Spring25'].apis, ...metaReleaseStats['Fall25'].apis]),
+              'Other': new Set([...metaReleaseStats['Fall24'].apis, ...metaReleaseStats['Spring25'].apis, ...metaReleaseStats['Fall25'].apis, ...metaReleaseStats['Other'].apis])
+            };
+            
+            // Calculate totals
+            const totals = {
+              repos: new Set(),
+              preReleases: 0,
+              publicReleases: 0,
+              patchReleases: 0,
+              apis: new Set()
+            };
+            
+            Object.values(metaReleaseStats).forEach(stats => {
+              stats.repos.forEach(r => totals.repos.add(r));
+              totals.preReleases += stats.preReleases;
+              totals.publicReleases += stats.publicReleases;
+              totals.patchReleases += stats.patchReleases;
+              stats.apis.forEach(a => totals.apis.add(a));
+            });
+            
+            // Build the table
+            report += '| Metric | Fall24 | Spring25 | Fall25 | Other | Total |\n';
+            report += '|--------|--------|----------|--------|-------|-------|\n';
+            
+            // Repository count row
+            report += `| **Repositories** | ${metaReleaseStats['Fall24'].repos.size} | ${metaReleaseStats['Spring25'].repos.size} | ${metaReleaseStats['Fall25'].repos.size} | ${metaReleaseStats['Other'].repos.size} | ${totals.repos.size} |\n`;
+            
+            // Release type rows
+            report += `| **Pre-releases** | ${metaReleaseStats['Fall24'].preReleases} | ${metaReleaseStats['Spring25'].preReleases} | ${metaReleaseStats['Fall25'].preReleases} | ${metaReleaseStats['Other'].preReleases} | ${totals.preReleases} |\n`;
+            report += `| **Public Releases** | ${metaReleaseStats['Fall24'].publicReleases} | ${metaReleaseStats['Spring25'].publicReleases} | ${metaReleaseStats['Fall25'].publicReleases} | ${metaReleaseStats['Other'].publicReleases} | ${totals.publicReleases} |\n`;
+            report += `| **Patch Releases** | ${metaReleaseStats['Fall24'].patchReleases} | ${metaReleaseStats['Spring25'].patchReleases} | ${metaReleaseStats['Fall25'].patchReleases} | ${metaReleaseStats['Other'].patchReleases} | ${totals.patchReleases} |\n`;
+            
+            // Single API row showing unique APIs (with equivalence handling)
+            report += `| **Unique APIs** | ${countUniqueAPIs(metaReleaseStats['Fall24'].apis)} | ${countUniqueAPIs(metaReleaseStats['Spring25'].apis)} | ${countUniqueAPIs(metaReleaseStats['Fall25'].apis)} | ${countUniqueAPIs(metaReleaseStats['Other'].apis)} | ${countUniqueAPIs(totals.apis)} |\n`;
+            
+            // Cumulative APIs row (with equivalence handling)
+            report += `| **Cumulative APIs** | ${countUniqueAPIs(cumulativeAPIs['Fall24'])} | ${countUniqueAPIs(cumulativeAPIs['Spring25'])} | ${countUniqueAPIs(cumulativeAPIs['Fall25'])} | ${countUniqueAPIs(cumulativeAPIs['Other'])} | - |\n`;
+            
+            report += '\n';
+            report += '*Note: Legacy releases and pre-releases are excluded from API counts, except for Fall25*\n';
+            if (allProcessingErrors.length > 0) {
+              report += `*⚠️ Warning: ${allProcessingErrors.length} repositories could not be analyzed - numbers may be incomplete*\n`;
+            }
+            report += '\n';
+            
+            // API Version Release Status Table - for meta-release specific reports
+            if (['fall25', 'spring25', 'fall24'].includes(filters.reportType)) {
+              report += '## API Version Release Status\n\n';
+              
+              // Build API-centric data structure
+              const apiStatusData = {};
+              const targetMetaRelease = filters.reportType === 'fall25' ? 'Fall25' : 
+                                       filters.reportType === 'spring25' ? 'Spring25' : 'Fall24';
+              
+              // Collect APIs from previous meta-releases for "New" flag detection
+              const previousAPIs = new Set();
+              if (targetMetaRelease === 'Fall25') {
+                // For Fall25, previous means Fall24 and Spring25
+                metaReleaseStats['Fall24'].apis.forEach(api => previousAPIs.add(api));
+                metaReleaseStats['Spring25'].apis.forEach(api => previousAPIs.add(api));
+              } else if (targetMetaRelease === 'Spring25') {
+                // For Spring25, previous means Fall24
+                metaReleaseStats['Fall24'].apis.forEach(api => previousAPIs.add(api));
+              }
+              // For Fall24, there are no previous meta-releases to check
+              
+              // Process repositories to build API status data
+              filteredRepositories.forEach(repo => {
+                // Find if this repository has releases for the target meta-release
+                const targetReleases = repo.releases.filter(release => {
+                  const cycle = release.meta_release.cycle;
+                  return cycle === targetMetaRelease || 
+                         (cycle === 'Patch' && release.meta_release.reason && release.meta_release.reason.includes(targetMetaRelease));
+                });
+                
+                if (targetReleases.length === 0) return;
+                
+                // Sort releases by date (newest first)
+                targetReleases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+                
+                // Find the latest public release and latest pre-release
+                const latestPublic = targetReleases.find(r => !r.prerelease);
+                const latestPreRelease = targetReleases.find(r => r.prerelease);
+                const latestRelease = targetReleases[0];
+                
+                // Process APIs from this repository
+                const seenAPIs = new Set();
+                targetReleases.forEach(release => {
+                  release.api_definitions.forEach(api => {
+                    // Skip non-kebab-case API names (they're likely old/incorrect naming)
+                    if (!api.name.match(/^[a-z]+(-[a-z]+)*$/)) return;
+                    
+                    // Only process each API once per repository (use latest data)
+                    if (seenAPIs.has(api.name)) return;
+                    seenAPIs.add(api.name);
+                    
+                    // Use the repository containing the target meta-release for this API
+                    if (!apiStatusData[api.name] || repo.releases.some(r => r.meta_release.cycle === targetMetaRelease)) {
+                      // Determine target version (from public release or stripped pre-release)
+                      let targetVersion = '';
+                      if (latestPublic) {
+                        // Use version from latest public release
+                        const publicAPI = latestPublic.api_definitions.find(a => a.name === api.name);
+                        targetVersion = publicAPI ? publicAPI.version : api.version;
+                      } else if (latestPreRelease) {
+                        // Strip pre-release suffix to get target version
+                        const preAPI = latestPreRelease.api_definitions.find(a => a.name === api.name);
+                        if (preAPI) {
+                          targetVersion = preAPI.version.replace(/-.*$/, '');
+                        } else {
+                          targetVersion = api.version.replace(/-.*$/, '');
+                        }
+                      }
+                      
+                      // Determine maturity
+                      const maturity = targetVersion.startsWith('0.') ? 'initial' : 'stable';
+                      
+                      // Get current version (from latest release)
+                      const currentAPI = latestRelease.api_definitions.find(a => a.name === api.name);
+                      const currentVersion = currentAPI ? currentAPI.version : api.version;
+                      
+                      // Get pre-release info if exists
+                      let preReleaseTag = '';
+                      let preReleaseDate = '';
+                      let preReleaseUrl = '';
+                      if (latestPreRelease) {
+                        const preAPI = latestPreRelease.api_definitions.find(a => a.name === api.name);
+                        if (preAPI && preAPI.version.includes('-')) {
+                          preReleaseTag = latestPreRelease.tag_name;
+                          preReleaseDate = new Date(latestPreRelease.published_at).toISOString().split('T')[0];
+                          preReleaseUrl = latestPreRelease.html_url;
+                        }
+                      }
+                      
+                      // Get first public release info for M4
+                      let m4ReleaseTag = '';
+                      let m4ReleaseDate = '';
+                      let m4ReleaseUrl = '';
+                      const firstPublic = targetReleases.filter(r => !r.prerelease).sort((a, b) => 
+                        new Date(a.published_at) - new Date(b.published_at))[0];
+                      if (firstPublic) {
+                        m4ReleaseTag = firstPublic.tag_name;
+                        m4ReleaseDate = new Date(firstPublic.published_at).toISOString().split('T')[0];
+                        m4ReleaseUrl = firstPublic.html_url;
+                      }
+                      
+                      // Check if API is new (considering equivalences)
+                      let isNew = true;
+                      // Check direct name
+                      if (previousAPIs.has(api.name)) {
+                        isNew = false;
+                      } else {
+                        // Check equivalences
+                        for (const group of API_EQUIVALENCES) {
+                          if (group.includes(api.name)) {
+                            // Check if any equivalent name exists in previous APIs
+                            for (const equivalentName of group) {
+                              if (previousAPIs.has(equivalentName)) {
+                                isNew = false;
+                                break;
+                              }
+                            }
+                            break;
+                          }
+                        }
+                      }
+                      
+                      apiStatusData[api.name] = {
+                        targetVersion,
+                        maturity,
+                        currentVersion,
+                        preReleaseTag,
+                        preReleaseDate,
+                        preReleaseUrl,
+                        m4ReleaseTag,
+                        m4ReleaseDate,
+                        m4ReleaseUrl,
+                        isNew,
+                        repository: repo.name,
+                        repositoryUrl: repo.html_url,
+                        latestReleaseTag: latestRelease.tag_name
+                      };
+                    }
+                  });
+                });
+                
+                // For Fall25, if no M4 release yet, look for M4 PRs
+                if (targetMetaRelease === 'Fall25') {
+                  Object.keys(apiStatusData).forEach(apiName => {
+                    const apiData = apiStatusData[apiName];
+                    
+                    // Only look for PRs if we don't already have an M4 release
+                    if (!apiData.m4ReleaseTag) {
+                      const apiRepo = filteredRepositories.find(r => r.name === apiData.repository);
+                      
+                      if (apiRepo && apiRepo.m4_prs && apiRepo.m4_prs.length > 0) {
+                        // Use the first M4 PR found (they should be rare)
+                        const m4PR = apiRepo.m4_prs[0];
+                        const draftLabel = m4PR.draft ? ' (draft)' : '';
+                        apiData.m4ReleaseTag = `PR [#${m4PR.number}](${m4PR.html_url})${draftLabel}`;
+                        apiData.m4ReleaseDate = '-';
+                        apiData.m4ReleaseUrl = ''; // Already included in the tag
+                      }
+                    }
+                  });
+                }
+              });
+              
+              // Generate the table
+              const sortedAPIs = Object.keys(apiStatusData).sort();
+              
+              if (sortedAPIs.length > 0) {
+                report += '| API (Target Version) | Maturity | Current Version | Pre-release | M3 Date | M4 Release | M4 Date | Repository | New |\n';
+                report += '|---------------------|----------|-----------------|-------------|---------|------------|---------|------------|-----|\n';
+                
+                sortedAPIs.forEach(apiName => {
+                  const data = apiStatusData[apiName];
+                  const apiWithVersion = `${apiName} (${data.targetVersion})`;
+                  const preRelease = data.preReleaseTag ? 
+                    `[${data.preReleaseTag}](${data.preReleaseUrl})` : '-';
+                  const m3Date = data.preReleaseDate || '-';
+                  const m4Release = data.m4ReleaseTag ? 
+                    (data.m4ReleaseUrl ? `[${data.m4ReleaseTag}](${data.m4ReleaseUrl})` : data.m4ReleaseTag) : '-';
+                  const m4Date = data.m4ReleaseDate || '-';
+                  const repository = `[${data.repository}](${data.repositoryUrl})`;
+                  const isNew = data.isNew ? 'Yes' : 'No';
+                  
+                  report += `| ${apiWithVersion} | ${data.maturity} | ${data.currentVersion} | ${preRelease} | ${m3Date} | ${m4Release} | ${m4Date} | ${repository} | ${isNew} |\n`;
+                });
+                
+                report += '\n';
+                report += '*Note: Target version is derived from the latest public release or by removing pre-release suffix from the latest pre-release.*\n';
+                report += '*M3 Date shows when the pre-release was published. M4 Date shows when the first public release was published.*\n';
+                if (targetMetaRelease === 'Fall25') {
+                  report += '*For Fall25, M4 Release may show a PR link for planned releases from open Pull Requests.*\n';
+                }
+                report += '\n';
+              } else {
+                report += '*No APIs found for this meta-release.*\n\n';
+              }
+              
+              // Export API status data as JSON for external visualization
+              if (sortedAPIs.length > 0 && ['fall25', 'spring25', 'fall24'].includes(filters.reportType)) {
+                const exportData = {
+                  metadata: {
+                    generated: new Date().toISOString(),
+                    metaRelease: targetMetaRelease,
+                    reportType: filters.reportType,
+                    totalAPIs: sortedAPIs.length,
+                    includesPrerelease: filters.includePrerelease
+                  },
+                  apis: []
+                };
+                
+                // Build API data array
+                sortedAPIs.forEach(apiName => {
+                  const data = apiStatusData[apiName];
+                  
+                  // Clean up PR links for export
+                  let m4ReleaseInfo = null;
+                  if (data.m4ReleaseTag) {
+                    if (data.m4ReleaseTag.startsWith('PR')) {
+                      const prMatch = data.m4ReleaseTag.match(/PR \[#(\d+)\]\((.*?)\)/);
+                      if (prMatch) {
+                        m4ReleaseInfo = {
+                          type: 'pr',
+                          number: prMatch[1],
+                          url: prMatch[2]
+                        };
+                      }
+                    } else {
+                      m4ReleaseInfo = {
+                        type: 'release',
+                        tag: data.m4ReleaseTag,
+                        url: data.m4ReleaseUrl
+                      };
+                    }
+                  }
+                  
+                  exportData.apis.push({
+                    name: apiName,
+                    targetVersion: data.targetVersion,
+                    maturity: data.maturity,
+                    currentVersion: data.currentVersion,
+                    preRelease: data.preReleaseTag ? {
+                      tag: data.preReleaseTag,
+                      date: data.preReleaseDate,
+                      url: data.preReleaseUrl
+                    } : null,
+                    m4Release: m4ReleaseInfo,
+                    m4Date: data.m4ReleaseDate || null,
+                    repository: {
+                      name: data.repository,
+                      url: data.repositoryUrl
+                    },
+                    isNew: data.isNew
+                  });
+                });
+                
+                // Save JSON file
+                const jsonTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
+                const jsonFilename = `api-status-${targetMetaRelease.toLowerCase()}-${jsonTimestamp}.json`;
+                fs.writeFileSync(jsonFilename, JSON.stringify(exportData, null, 2));
+                console.log(`✅ Exported API status data: ${jsonFilename}`);
+              }
+            }
+            
+            // Recent releases section - FIXED
+            if (recentReleases.length > 0 && filters.recentDaysWindow > 0) {
+              report += `## Recent Releases (Last ${filters.recentDaysWindow} Days)\n\n`;
+              report += '| Repository | Repo Type | Release | Type | APIs | Date | Meta-Release |\n';
+              report += '|------------|-----------|---------|------|------|------|-------------|\n';
+              
+              recentReleases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+              
+              for (const release of recentReleases) {
+                const date = new Date(release.published_at).toLocaleDateString();
+                const name = release.name || release.tag_name;
+                
+                // Use the new release_type field
+                const releaseType = release.release_type || (release.prerelease ? 'pre-release' : 'public-release');
+                let typeDisplay = '';
+                if (releaseType === 'pre-release') typeDisplay = 'Pre-release';
+                else if (releaseType === 'public-release') typeDisplay = 'Public';
+                else if (releaseType === 'patch-release') typeDisplay = 'Patch';
+                else typeDisplay = 'Release';
+                
+                const apiList = release.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
+                
+                // Meta-release should never be "Patch" - it's always the actual meta-release
+                const metaRelease = release.meta_release.cycle;
+                
+                // FIXED: Use the stored repository information instead of trying to find it
+                report += `| [${release.repository_name}](${release.repository_html_url}) | ${release.repository_type} | [${name}](${release.html_url}) | ${typeDisplay} | ${apiList} | ${date} | ${metaRelease} |\n`;
+              }
+              report += '\n';
+            }
+            
+            // Consistency analysis (only if requested)
+            const consistencyIssues = [];
+            
+            if (filters.includeConsistencyAnalysis) {
+              report += '## Consistency Analysis\n\n';
+              if (filters.reportType !== 'full') {
+                report += `*Note: This analysis is filtered to ${filters.reportType} repositories only*\n\n`;
+              } else if (!filters.includePrerelease) {
+                report += '*Note: This analysis reflects applied filters - pre-releases are excluded*\n\n';
+              }
+            
+            // Use filtered repositories based on report type
+            const reposToAnalyze = filteredRepositories;
+            
+            for (const repo of reposToAnalyze) {
+              // Filter releases for consistency analysis based on report type
+              const filteredReleases = repo.releases.filter(release => {
+                const cycle = release.meta_release.cycle;
+                const releaseType = release.release_type || (release.prerelease ? 'pre-release' : 'public-release');
+                
+                // Exclude pre-releases if not included
+                if (!filters.includePrerelease && releaseType === 'pre-release') return false;
+                
+                // Apply report type filtering based on meta-release cycle
+                switch(filters.reportType) {
+                  case 'fall25':
+                    return cycle === 'Fall25';
+                  case 'spring25':
+                    return cycle === 'Spring25';
+                  case 'fall24':
+                    return cycle === 'Fall24';
+                  case 'full-no-legacy':
+                    return cycle !== 'Legacy';
+                  default:
+                    return true;
+                }
+              });
+              
+              if (filteredReleases.length === 0) continue;
+              
+              // Get the latest release (including pre-releases) for version consistency check
+              const allReleasesForConsistency = repo.releases.slice().sort((a, b) => 
+                new Date(b.published_at) - new Date(a.published_at)
+              );
+              const latestReleaseIncludingPre = allReleasesForConsistency[0];
+              
+              // Check main branch vs latest release version consistency
+              // Should check against latest release INCLUDING pre-releases
+              for (const mainAPI of repo.main_branch_apis) {
+                const correspondingReleaseAPI = latestReleaseIncludingPre ? 
+                  latestReleaseIncludingPre.api_definitions.find(api => api.name === mainAPI.name) : null;
+                
+                if (correspondingReleaseAPI) {
+                  if (mainAPI.version !== correspondingReleaseAPI.version && mainAPI.version !== 'wip') {
+                    const releaseType = latestReleaseIncludingPre.prerelease ? 'pre-release' : 'release';
+                    consistencyIssues.push({
+                      repo: repo.name,
+                      type: 'Version Mismatch',
+                      description: `${mainAPI.name}: main branch v${mainAPI.version} ≠ latest ${releaseType} v${correspondingReleaseAPI.version} (should be same or "wip")`
+                    });
+                  }
+                }
+              }
+              
+              // Check release descriptions mention API versions
+              for (const release of filteredReleases.slice(0, 3)) {
+                for (const api of release.api_definitions) {
+                  if (!release.body.includes(api.version)) {
+                    consistencyIssues.push({
+                      repo: repo.name,
+                      type: 'Missing Version in Description',
+                      description: `${release.tag_name}: API ${api.name} v${api.version} not mentioned in release description`
+                    });
+                  }
+                }
+              }
+            }
+            
+            if (consistencyIssues.length > 0) {
+              report += '### Consistency Issues Found\n\n';
+              report += '| Repository | Issue Type | Description |\n';
+              report += '|------------|------------|-------------|\n';
+              
+              for (const issue of consistencyIssues.slice(0, 20)) {
+                report += `| ${issue.repo} | ${issue.type} | ${issue.description} |\n`;
+              }
+              
+              if (consistencyIssues.length > 20) {
+                report += `\n*Showing first 20 of ${consistencyIssues.length} issues*\n`;
+              }
+              report += '\n';
+            } else {
+              report += '✅ No consistency issues found!\n\n';
+            }
+            } // End of consistency analysis if block
+            
+            // Detailed repository analysis (optional)
+            if (filters.showRepositoryDetails) {
+              report += '## Detailed Repository Analysis\n\n';
+            
+            // Add filter note if not showing everything
+            if (filters.reportType !== 'full' || !filters.includePrerelease) {
+              report += '*Note: ';
+              if (filters.reportType !== 'full') {
+                report += `Showing ${filters.reportType} repositories`;
+              }
+              if (!filters.includePrerelease) {
+                if (filters.reportType !== 'full') report += ' and ';
+                report += 'pre-releases are excluded';
+              }
+              report += '*\n\n';
+            }
+            
+            // Use filtered repositories for details
+            const reposForDetails = filteredRepositories;
+            
+            for (const repo of reposForDetails.sort((a, b) => a.name.localeCompare(b.name))) {
+              // Filter releases for detailed analysis
+              let filteredReleases;
+              if (filters.reportType !== 'full') {
+                // For meta-release reports: show all meta-releases and patches, exclude "Other release" and "Legacy"
+                filteredReleases = repo.releases.filter(release => {
+                  const cycle = release.meta_release.cycle;
+                  return ['Fall24', 'Spring25', 'Fall25', 'Patch', 'Pre-release'].includes(cycle);
+                });
+              } else {
+                // Standard filtering
+                filteredReleases = repo.releases.filter(release => {
+                  const cycle = release.meta_release.cycle;
+                  if (!filters.includePrerelease && cycle === 'Pre-release') return false;
+                  if (filters.reportType !== 'full' && cycle === 'Legacy') return false;
+                  return true;
+                });
+              }
+              
+              // Skip repositories with no releases after filtering
+              if (filteredReleases.length === 0) continue;
+              
+              // Don't show type (Sandbox/Incubating) in title for cleaner output
+              report += `### [${repo.name}](${repo.html_url})\n\n`;
+              
+              if (repo.main_branch_apis.length > 0) {
+                report += '**Main Branch APIs:**\n';
+                for (const api of repo.main_branch_apis) {
+                  report += `- ${api.name}: v${api.version}\n`;
+                }
+                report += '\n';
+              }
+              
+              report += '**Release History:**\n';
+              report += '| Release | Date | Type | Meta-Release | APIs |\n';
+              report += '|---------|------|------|--------------|------|\n';
+              
+              for (const release of filteredReleases.slice(0, 5)) {
+                const date = new Date(release.published_at).toLocaleDateString();
+                
+                // Use the new release_type field
+                const releaseType = release.release_type || (release.prerelease ? 'pre-release' : 'public-release');
+                let typeDisplay = '';
+                if (releaseType === 'pre-release') typeDisplay = 'Pre-release';
+                else if (releaseType === 'public-release') typeDisplay = 'Public';
+                else if (releaseType === 'patch-release') typeDisplay = 'Patch';
+                else typeDisplay = 'Release';
+                
+                // Meta-release should never be "Patch" - it's always the actual meta-release
+                const metaRelease = release.meta_release.cycle;
+                
+                const apiList = release.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
+                
+                report += `| [${release.tag_name}](${release.html_url}) | ${date} | ${typeDisplay} | ${metaRelease} | ${apiList} |\n`;
+              }
+              report += '\n';
+            }
+            
+            } // End of showRepositoryDetails conditional
+            
+            // Repositories with pre-releases only - show when pre-releases are included
+            if (filters.includePrerelease && allRepositoriesWithPrereleasesOnly.length > 0) {
+              // Filter pre-release-only repos based on report type
+              let filteredPreReleaseRepos = allRepositoriesWithPrereleasesOnly;
+              
+              if (filters.reportType !== 'full') {
+                // For non-full reports, check if repo would be included in the filtered list
+                const filteredRepoNames = new Set(filteredRepositories.map(r => r.name));
+                
+                // Also check if the pre-release repos have any releases matching the filter
+                // This handles the case where a repo has only pre-releases but they match the meta-release
+                filteredPreReleaseRepos = allRepositoriesWithPrereleasesOnly.filter(repo => {
+                  // Check if it's in the filtered repositories list (has matching public releases)
+                  if (filteredRepoNames.has(repo.name)) return true;
+                  
+                  // For meta-release reports, check if repo has any releases with matching meta-release
+                  // Look at actual meta-release assignments instead of just flags
+                  const matchingRepo = allRepositories.find(r => r.name === repo.name);
+                  if (matchingRepo) {
+                    const hasMatchingRelease = matchingRepo.releases.some(release => {
+                      const cycle = release.meta_release.cycle;
+                      switch(filters.reportType) {
+                        case 'fall25':
+                          return cycle === 'Fall25';
+                        case 'spring25':
+                          return cycle === 'Spring25';
+                        case 'fall24':
+                          return cycle === 'Fall24';
+                        default:
+                          return false;
+                      }
+                    });
+                    if (hasMatchingRelease) return true;
+                  }
+                  
+                  // Otherwise exclude it
+                  return false;
+                });
+              }
+              
+              if (filteredPreReleaseRepos.length > 0) {
+                report += '## API Repositories with Pre-releases Only\n\n';
+                report += '*These repositories have releases but only pre-releases, no public releases yet.*\n\n';
+                report += '| Repository | Type | Pre-releases | Main Branch APIs | Pre-release APIs |\n';
+                report += '|------------|------|--------------|------------------|-----------------|\n';
+                
+                for (const repo of filteredPreReleaseRepos.sort((a, b) => a.name.localeCompare(b.name))) {
+                  const mainAPIs = repo.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
+                  const prereleaseAPIs = repo.prerelease_apis.join('<br>');
+                  
+                  report += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${repo.prerelease_count} | ${mainAPIs} | ${prereleaseAPIs} |\n`;
+                }
+                report += '\n';
+              }
+            }
+            
+            // Repositories without releases
+            if (allRepositoriesWithoutReleases.length > 0) {
+              report += '## API Repositories Without Releases\n\n';
+              report += '| Repository | Type | API Definitions Found |\n';
+              report += '|------------|------|-----------------------|\n';
+              
+              for (const repo of allRepositoriesWithoutReleases.sort((a, b) => a.name.localeCompare(b.name))) {
+                const apiList = repo.api_definitions.map(api => `${api.name} v${api.version}`).join('<br>');
+                
+                report += `| [${repo.name}](${repo.html_url}) | ${repo.repo_type} | ${apiList} |\n`;
+              }
+              report += '\n';
+            }
+            
+            // Save final report
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const filename = `camara-api-releases-parallel-${timestamp.split('T')[0]}.md`;
+            fs.writeFileSync(filename, report);
+            
+            // Set outputs for summary
+            core.setOutput('total_api_repos', totalApiRepos);
+            core.setOutput('repos_with_releases', allRepositories.length);
+            core.setOutput('repos_without_releases', allRepositoriesWithoutReleases.length);
+            core.setOutput('repos_prerelease_only', allRepositoriesWithPrereleasesOnly.length);
+            core.setOutput('total_releases', totalReleasesAnalyzed);
+            core.setOutput('recent_releases', recentReleases.length);
+            core.setOutput('consistency_issues', consistencyIssues.length);
+            core.setOutput('unique_apis', totals.apis.size);
+            core.setOutput('report_type', filters.reportType);
+            core.setOutput('include_prerelease', filters.includePrerelease);
+            
+            console.log(`✅ Parallel API releases report saved as ${filename}`);
+            console.log('📊 Final Statistics:');
+            console.log(`  - Processing time: ~3-5 minutes (vs 15-20 minutes sequential)`);
+            console.log(`  - Repositories analyzed: ${totalApiRepos}`);
+            console.log(`  - Repositories with releases: ${allRepositories.length}`);
+            console.log(`  - Repositories with pre-releases only: ${allRepositoriesWithPrereleasesOnly.length}`);
+            console.log(`  - Repositories without releases: ${allRepositoriesWithoutReleases.length}`);
+            console.log(`  - Recent releases found: ${recentReleases.length}`);
+            console.log(`  - Consistency issues: ${consistencyIssues.length}`);
+            console.log(`  - Processing errors: ${allProcessingErrors.length}`);
+            console.log(`  - Report type: ${filters.reportType}`);
+            if (filters.reportType !== 'full') {
+              console.log(`  - Filtered repositories: ${filteredRepositories.length}`);
+            }
+            console.log(`  - Filters: includePrerelease=${filters.includePrerelease}`);
+            
+            core.setOutput('report_filename', filename);
+            
+            // Create job summary
+            const shortSummary = report.split('\n').slice(0, 50).join('\n') + '\n\n*Full detailed report available in artifacts*';
+            core.summary.addRaw(shortSummary);
+            await core.summary.write();
+            
+            console.log('🎉 Parallel CAMARA API releases report generation completed!');
+
+      - name: Upload Final API Releases Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: camara-api-releases-${{ github.run_number }}
+          path: |
+            *.md
+            api-status-*.json
+          retention-days: 90
+
+  # ============================================
+  # JOB 4: WORKFLOW SUMMARY
+  # Purpose: Generate final execution summary for GitHub Actions UI
+  # ============================================
+  final-summary:
+    if: always()
+    needs: [generate-report, combine-api-analysis]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Workflow Summary
+        run: |
+          echo "# 📦 CAMARA API Releases Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Generated At**: $(date -u)" >> $GITHUB_STEP_SUMMARY
+          echo "**Job Status**: ${{ needs.combine-api-analysis.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Processing Method**: Parallel Matrix Analysis" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.combine-api-analysis.result }}" = "success" ]; then
+            echo "## 📊 API Release Statistics" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+            echo "| **API Repositories Analyzed** | ${{ needs.combine-api-analysis.outputs.total_api_repos }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Repositories with Releases** | ${{ needs.combine-api-analysis.outputs.repos_with_releases }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Repositories with Pre-releases Only** | ${{ needs.combine-api-analysis.outputs.repos_prerelease_only }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Repositories without Releases** | ${{ needs.combine-api-analysis.outputs.repos_without_releases }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Total Releases Analyzed** | ${{ needs.combine-api-analysis.outputs.total_releases }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Recent Releases (${{ github.event.inputs.recent_days_window || '30' }} days)** | ${{ needs.combine-api-analysis.outputs.recent_releases }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Unique APIs Found** | ${{ needs.combine-api-analysis.outputs.unique_apis }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Consistency Issues** | ${{ needs.combine-api-analysis.outputs.consistency_issues }} |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            echo "## ⚙️ Analysis Configuration" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            echo "- **Report Type**: ${{ needs.combine-api-analysis.outputs.report_type }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Include Pre-releases**: ${{ needs.combine-api-analysis.outputs.include_prerelease == 'true' && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Include Dev Status**: ${{ needs.combine-api-analysis.outputs.include_dev_status == 'true' && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            
+            echo "- **Meta-release Analysis**: ✅ Fall24, Spring25, Fall25 categorization" >> $GITHUB_STEP_SUMMARY
+            echo "- **API Definitions**: ✅ Extracted from releases and main branch" >> $GITHUB_STEP_SUMMARY
+            echo "- **Consistency Checks**: ✅ Main branch vs release comparison" >> $GITHUB_STEP_SUMMARY
+            
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "## ⚡ Performance" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- **Processing Time**: ~3-5 minutes (vs 15-20 minutes sequential)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Parallel Groups**: ${{ needs.generate-report.outputs.total_groups }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Repositories per Group**: 8" >> $GITHUB_STEP_SUMMARY
+            echo "- **Max Parallel**: 6 groups simultaneously" >> $GITHUB_STEP_SUMMARY
+            
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "## 📥 Download Report" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The complete detailed report is available in the **Artifacts** section below." >> $GITHUB_STEP_SUMMARY
+            echo "Look for: \`camara-api-releases-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+            
+          else
+            echo "## ❌ Workflow Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The API releases workflow encountered an error." >> $GITHUB_STEP_SUMMARY
+            echo "Please check the workflow logs for detailed error information." >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "*CAMARA API Releases Workflow*" >> $GITHUB_STEP_SUMMARY
+          
+          echo "✅ CAMARA API releases workflow completed"
+          echo "📅 Completed at: $(date -u)"
+          echo "⚡ Used parallel processing for faster API analysis"
+          echo "📁 Artifact uploaded and available for download"

--- a/.github/workflows/project-report-camara-api-releases.yml
+++ b/.github/workflows/project-report-camara-api-releases.yml
@@ -1,6 +1,10 @@
 # =========================================================================================
 # CAMARA Project - API Releases Report Workflow
 #
+# NOTE: This workflow is maintained for backward compatibility only.
+#       For new features and meta-release support, use meta-release-reporting.yml
+#       This workflow will be deprecated in the future.
+#
 # This GitHub Actions workflow analyzes API releases across CAMARA repositories with
 # parallel processing, meta-release categorization, and consistency validation.
 #

--- a/documentation/meta-release-reporting-workflow.md
+++ b/documentation/meta-release-reporting-workflow.md
@@ -53,6 +53,14 @@ show_repository_details:
   description: 'Include detailed repository analysis'
   default: false
 
+show_prerelease_only_repos:
+  description: 'Show repositories with only pre-releases'
+  default: false
+
+show_repos_without_releases:
+  description: 'Show repositories without any releases'
+  default: false
+
 include_consistency_analysis:
   description: 'Include consistency analysis'
   default: false
@@ -82,11 +90,13 @@ For meta-release reports (Fall25, Spring25, Fall24), displays:
 ### 4. Optional Sections
 - **Recent Releases**: Releases within specified days window
 - **Repository Details**: Detailed per-repository analysis
+- **Pre-release Only Repos**: Repositories with only pre-releases (no public releases)
+- **Repos Without Releases**: Repositories without any releases
 - **Consistency Analysis**: Version and release consistency checks
 
 ## JSON Export Format
 
-The workflow exports structured JSON for visualization:
+The workflow exports structured JSON for meta-release reports (Fall25, Spring25, Fall24) to enable visualization:
 
 ```json
 {
@@ -126,8 +136,10 @@ The workflow exports structured JSON for visualization:
 
 The JSON export can be visualized using the CAMARA API Status Viewer:
 1. Download the JSON artifact from the workflow run
-2. Open the viewer (will be at https://camaraproject.github.io/release-management/api-status-viewer.html)
+2. Open the viewer at https://camaraproject.github.io/api-status-viewer (coming soon)
 3. Load the JSON file to see an interactive table with sorting and CSV export
+
+Note: JSON export is currently only available for meta-release reports (Fall25, Spring25, Fall24), not for Full reports.
 
 ## Configuration
 

--- a/documentation/meta-release-reporting-workflow.md
+++ b/documentation/meta-release-reporting-workflow.md
@@ -1,0 +1,214 @@
+# Meta-Release Reporting Workflow v2
+
+*Last updated: 2025-09-08*
+
+## Overview
+
+The `meta-release-reporting.yml` workflow is a comprehensive GitHub Actions workflow for tracking and reporting on CAMARA API releases across meta-release cycles (Fall24, Spring25, Fall25, etc.). This v2 workflow replaces the original `project-report-camara-api-releases.yml` with significant enhancements.
+
+## Key Features
+
+### Meta-Release Support
+- **Fall25**: Tracks M3 pre-release window (July 10 - Aug 13, 2025) and M4 milestones
+- **Spring25**: February - March 2025 release window
+- **Fall24**: August - September 2024 release window
+- Automatic categorization of releases into meta-release cycles
+- Consistent handling of patch releases within meta-release series
+
+### API Version Release Status Table
+- Primary output for meta-release reports (Fall25, Spring25, Fall24)
+- Shows target version, maturity level, current version
+- Tracks M3 pre-release dates and M4 release/PR status
+- Identifies new APIs vs existing ones
+- Links directly to repositories and releases
+
+### Data Export
+- Generates structured JSON for external visualization
+- Compatible with the CAMARA API Status Viewer
+- Includes comprehensive metadata and versioning
+- Enables trend analysis and reporting dashboards
+
+## Workflow Inputs
+
+```yaml
+report_type:
+  description: 'Report type to generate'
+  options:
+    - 'fall25'       # Default - Fall 2025 meta-release
+    - 'spring25'     # Spring 2025 meta-release
+    - 'fall24'       # Fall 2024 meta-release
+    - 'full'         # All repositories and releases
+    - 'full-no-legacy' # All except legacy releases
+  default: 'fall25'
+
+include_prerelease:
+  description: 'Include pre-releases in the report'
+  default: true      # Changed from false in v1
+
+recent_days_window:
+  description: 'Recent releases section (0 to disable)'
+  default: 30
+
+show_repository_details:
+  description: 'Include detailed repository analysis'
+  default: false
+
+include_consistency_analysis:
+  description: 'Include consistency analysis'
+  default: false
+```
+
+## Report Sections
+
+### 1. Executive Summary
+Always displayed, showing:
+- Total API repositories analyzed
+- Repositories with releases/pre-releases/no releases
+- Processing errors if any
+
+### 2. Meta-Release Summary
+For full reports, shows comprehensive statistics by meta-release
+
+### 3. API Version Release Status
+For meta-release reports (Fall25, Spring25, Fall24), displays:
+- API name and target version
+- Maturity level (initial/stable)
+- Current version in latest release
+- M3 pre-release information
+- M4 release or PR status
+- Repository links
+- New API indicators
+
+### 4. Optional Sections
+- **Recent Releases**: Releases within specified days window
+- **Repository Details**: Detailed per-repository analysis
+- **Consistency Analysis**: Version and release consistency checks
+
+## JSON Export Format
+
+The workflow exports structured JSON for visualization:
+
+```json
+{
+  "metadata": {
+    "generated": "2025-09-08T...",
+    "metaRelease": "Fall25",
+    "reportType": "fall25",
+    "totalAPIs": 25
+  },
+  "apis": [
+    {
+      "name": "qod",
+      "targetVersion": "1.0.0",
+      "maturity": "stable",
+      "currentVersion": "1.0.0-rc.1",
+      "preRelease": {
+        "tag": "r1.1-rc",
+        "date": "2025-07-15",
+        "url": "https://..."
+      },
+      "m4Release": {
+        "type": "pr",
+        "number": "123",
+        "url": "https://..."
+      },
+      "repository": {
+        "name": "QualityOnDemand",
+        "url": "https://..."
+      },
+      "isNew": false
+    }
+  ]
+}
+```
+
+## Viewing JSON Output
+
+The JSON export can be visualized using the CAMARA API Status Viewer:
+1. Download the JSON artifact from the workflow run
+2. Open the viewer (will be at https://camaraproject.github.io/release-management/api-status-viewer.html)
+3. Load the JSON file to see an interactive table with sorting and CSV export
+
+## Configuration
+
+### Environment Variables
+```yaml
+# Processing Configuration
+CONFIG_REPOS_PER_GROUP: '8'
+CONFIG_MAX_PARALLEL: '6'
+CONFIG_RELEASES_PER_PAGE: '100'
+CONFIG_API_DELAY_MS: '300'
+
+# Meta-release Windows
+FALL25_M3_START: '2025-07-10'
+FALL25_M3_END: '2025-08-13'
+SPRING25_WINDOW_START: '2025-02-01'
+SPRING25_WINDOW_END: '2025-03-31'
+```
+
+### API Name Equivalences
+Handles renamed APIs (e.g., `qod-provisioning` → `qos-provisioning`)
+
+## Usage Examples
+
+### Generate Fall25 Report (Default)
+```bash
+# Uses defaults: fall25, includes pre-releases
+gh workflow run meta-release-reporting.yml
+```
+
+### Generate Spring25 Report without Pre-releases
+```bash
+gh workflow run meta-release-reporting.yml \
+  -f report_type=spring25 \
+  -f include_prerelease=false
+```
+
+### Full Report with All Sections
+```bash
+gh workflow run meta-release-reporting.yml \
+  -f report_type=full \
+  -f show_repository_details=true \
+  -f include_consistency_analysis=true
+```
+
+## Migration from v1
+
+The original `project-report-camara-api-releases.yml` workflow remains available for backward compatibility but is deprecated. Key differences:
+
+| Feature | v1 | v2 (meta-release-reporting) |
+|---------|----|-----------------------------|
+| Default report | full | fall25 |
+| Pre-releases default | excluded | included |
+| Release fetch limit | 20 | 100 |
+| M4 PR detection | Not available | Fall25 milestone tracking |
+| Code structure | Monolithic | Modular |
+
+## Requirements
+
+- **GitHub Token**: Uses the default `GITHUB_TOKEN` (all CAMARA repositories are public)
+- **Optional**: `CAMARA_REPORT_TOKEN` can be used for higher API rate limits
+- **Runtime**: Approximately 3-5 minutes for full organization scan
+
+## Troubleshooting
+
+### Rate Limit Issues
+- Use `CAMARA_REPORT_TOKEN` with higher rate limits
+- Reduce parallel processing if needed
+
+### Missing Data
+- Check if repositories have correct topics (sandbox-api-repository or incubating-api-repository)
+- Verify release tags follow rX.Y format
+- Ensure API definitions are in `code/API_definitions/`
+
+### JSON Export Issues
+- Verify the workflow completed successfully
+- Check artifacts section of the workflow run
+- Ensure JSON viewer has access to load the file
+
+## Support
+
+For issues or questions:
+- Check the [workflow logs](https://github.com/camaraproject/project-administration/actions)
+- Review this documentation
+- Contact the CAMARA project administration team

--- a/documentation/meta-release-reporting-workflow.md
+++ b/documentation/meta-release-reporting-workflow.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The `meta-release-reporting.yml` workflow is a comprehensive GitHub Actions workflow for tracking and reporting on CAMARA API releases across meta-release cycles (Fall24, Spring25, Fall25, etc.). This v2 workflow replaces the original `project-report-camara-api-releases.yml` with significant enhancements.
+The `meta-release-reporting.yml` workflow is a GitHub Actions workflow for tracking and reporting on CAMARA API releases across meta-release cycles (Fall24, Spring25, Fall25, etc.). This v2 workflow replaces the original `project-report-camara-api-releases.yml`.
 
 ## Key Features
 
@@ -25,7 +25,7 @@ The `meta-release-reporting.yml` workflow is a comprehensive GitHub Actions work
 ### Data Export
 - Generates structured JSON for external visualization
 - Compatible with the CAMARA API Status Viewer
-- Includes comprehensive metadata and versioning
+- Includes metadata and versioning
 - Enables trend analysis and reporting dashboards
 
 ## Workflow Inputs
@@ -75,7 +75,7 @@ Always displayed, showing:
 - Processing errors if any
 
 ### 2. Meta-Release Summary
-For full reports, shows comprehensive statistics by meta-release
+For full reports, shows statistics by meta-release
 
 ### 3. API Version Release Status
 For meta-release reports (Fall25, Spring25, Fall24), displays:

--- a/documentation/project-report-generation-workflows.md
+++ b/documentation/project-report-generation-workflows.md
@@ -2,6 +2,10 @@
 
 *Last updated: 2025-06-18*
 
+> **⚠️ DEPRECATION NOTICE**: The `project-report-camara-api-releases.yml` workflow described in this document is maintained for backward compatibility only. 
+> For new features and meta-release support (Fall25, Spring25, etc.), please use the new `meta-release-reporting.yml` workflow.
+> See [Meta-Release Reporting Documentation](meta-release-reporting-workflow.md) for details.
+
 ## Table of Contents
 1. [Overview](#overview)
 2. [Quick Start](#quick-start)


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

This PR introduces the **Meta-Release Reporting Workflow v2** (`meta-release-reporting.yml`) for tracking and reporting CAMARA API releases aligned with meta-release milestones (Fall25, Spring25, Fall24).

**Key Features:**
- **Meta-release support**: Tracking for Fall25, Spring25, and Fall24 meta-release windows
- **API Version Release Status table**: Table showing API release status, versions, and meta-release timelines
- **Additional report sections**: Optional sections for pre-release-only repositories and repositories without releases
- **Performance**: Increased release fetch limit (20→100), utility functions without duplication
- **Updated defaults**: Fall25 as default report type, pre-releases included by default
- **JSON export**: Machine-readable format for visualization tools (meta-release reports only)
- **M4 milestone tracking**: Detection of Fall25 M4 PRs for release tracking

**Implementation Details:**
- Configuration via environment variables
- Utility functions without duplication
- Fixed version mismatch detection to include pre-releases
- Backward compatibility with deprecation notices on original workflow
- ~1914 lines of code

#### Which issue(s) this PR fixes:

N/A - Enhancement for meta-release reporting needs

#### Special notes for reviewers:

1. **Backward Compatibility**: The original workflow (`project-report-camara-api-releases.yml`) remains unchanged with deprecation notices added. Users can continue using the existing workflow while transitioning to v2.

2. **Testing Completed**: 
   - Tested with all 5 report types (Fall25, Spring25, Fall24, Full, Full-no-legacy)
   - All optional sections tested
   - JSON export tested
   - Workflow execution time: ~2 minutes

3. **Documentation**: Documentation included in `documentation/meta-release-reporting-workflow.md` with usage examples and configuration options.

4. **Migration Path**: Users can run both workflows in parallel during transition. The v2 workflow uses a different filename to avoid conflicts.

5. **Viewer Component**: HTML viewer for the JSON output available in PR [camaraproject/camaraproject.github.io#2](https://github.com/camaraproject/camaraproject.github.io/pull/2)

#### Changelog input

```
release-note
- Added new meta-release-reporting.yml workflow with Fall25, Spring25, Fall24 support
- Added API Version Release Status table for meta-release tracking
- Added JSON export capability for external visualization
- Added M4 milestone PR detection for Fall25 release readiness
- Added optional report sections for pre-release-only and no-release repositories
- Improved release fetching with 100-item limit (was 20)
- Fixed version mismatch detection to properly handle pre-releases
- Optimized with utility functions and modular report generation
```

#### Additional documentation 

```
docs
New workflow documentation available at:
- documentation/meta-release-reporting-workflow.md

The original workflow documentation has been updated with deprecation notices:
- documentation/project-report-generation-workflows.md
```
