### PR TITLE
Change campaign commit author to hdamker-bot for EasyCLA

### DIFF
--- a/.github/workflows/campaign-release-info.yml
+++ b/.github/workflows/campaign-release-info.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   MODE: ${{ inputs.dry_run && 'plan' || 'apply' }}
-  ORG: hdamker
+  ORG: camaraproject
   RELEASES_FILE: data/releases-master.yaml
   INCLUDE: "QualityOnDemand,QoSBooking,SimSwap"
   BRANCH: bulk/release-info-sync-${{ github.run_id }}


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Changes commit author identity from `github-actions[bot]` to `hdamker-bot` in the campaign-release-info workflow to resolve EasyCLA validation issues.

The `github-actions[bot]` identity is not on the CAMARA EasyCLA allowlist, causing CLA check failures for campaign-created PRs. The `hdamker-bot` identity is known to EasyCLA and will pass validation.

**Changes:**
- `actions/campaign-finalize-per-repo/action.yml` lines 216-217: Updated git config to use hdamker-bot

#### Which issue(s) this PR fixes:

Fixes #29

#### Special notes for reviewers:

Testing on fork confirmed workflow executes correctly and creates commits with hdamker-bot identity. Final EasyCLA validation will occur after merge when workflow runs against camaraproject repositories.

#### Changelog input

```release-note
Change campaign commit author to hdamker-bot for EasyCLA compatibility
```

#### Additional documentation

```docs

```
