### PR TITLE
Improve campaign templates based on feedback

### DIFF
--- a/campaigns/release-info/templates/pr-body.mustache
+++ b/campaigns/release-info/templates/pr-body.mustache
@@ -25,11 +25,14 @@ in a harmonized way across all API Repositories in Fall25.
 
 #### Review Checklist
 
-- [ ] Verify the release information is accurate
-- [ ] Check that API names and versions are correct
-- [ ] Confirm all documentation links work
+**Review Focus:** Verify delimiter placement and section structure only.
+
+**Content Validation Not Required:** Release versions, dates, API names, and documentation links are automatically synchronized from [releases-master.yaml](https://github.com/camaraproject/project-administration/blob/main/data/releases-master.yaml) and maintained by Release Management.
+
+- [ ] Verify delimiters are correctly placed (wrapping entire "## Release Information" section)
+- [ ] Confirm section heading remains "## Release Information"
 - [ ] Move any custom content outside delimiters (if needed)
-- [ ] Verify the section heading remains "## Release Information"
+- [ ] Check that the automated content does not conflict with other README sections
 
 ### Automation
 

--- a/campaigns/release-info/templates/release-info.mustache
+++ b/campaigns/release-info/templates/release-info.mustache
@@ -5,8 +5,11 @@
 > [!NOTE]
 > Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 
-* **NEW**: The latest public release is [{{latest_public_release}}]({{github_url}}), with the following API versions:
+* **NEW**: The latest public release is [{{latest_public_release}}]({{github_url}}) ({{meta_release}}), with the following API versions:
 {{formatted_apis}}
 * The latest public release is always available here: https://github.com/camaraproject/{{repo_name}}/releases/latest
 * Other releases of this repository are available in https://github.com/camaraproject/{{repo_name}}/releases
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/{{repo_name}}/blob/main/CHANGELOG.md)
+
+---
+_This section is automatically synchronized by CAMARA project-administration from [data/releases-master.yaml](https://github.com/camaraproject/project-administration/blob/main/data/releases-master.yaml)._


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Improves campaign templates based on codeowner feedback from issue #28:

1. **Adds meta-release reference** (e.g., Fall25, Spring25) to help users understand which meta-release cycle the APIs belong to
2. **Adds visible automation notice** at end of Release Information section explaining the content is synchronized from releases-master.yaml
3. **Clarifies PR review scope** in PR body template - codeowners should focus on delimiter placement and structure, not content validation (which is maintained by Release Management)

**Template Changes:**
- `campaigns/release-info/templates/release-info.mustache`: Added meta-release tag and visible automation notice
- `campaigns/release-info/templates/pr-body.mustache`: Updated review checklist to clarify review scope

#### Which issue(s) this PR fixes:

Fixes #31

#### Special notes for reviewers:

This PR addresses immediate feedback that doesn't require data source changes. **Please keep this PR open for additional template feedback** before merging.

Deferred to separate enhancement issue: Adding maturity level (requires switching to all-releases.json data source with enriched data).

#### Changelog input

```release-note
Improve campaign templates with meta-release reference and clearer review guidance
```

#### Additional documentation

```docs

```
