### PR TITLE
Fix ConnectivityInsights API metadata issues in release collector

### DIFF
--- a/workflows/release-collector/scripts/analyze-release.js
+++ b/workflows/release-collector/scripts/analyze-release.js
@@ -169,14 +169,29 @@ async function analyzeLocalRelease(repoPath, releaseTag) {
           commonalities: spec.info['x-camara-commonalities'] || null
         };
 
+        // Apply format corrections only (not content changes)
+        const correctedApi = applyFormatCorrections(apiData);
+
+        // Repository/release-specific corrections
+        if (repoName === 'ConnectivityInsights' && releaseTag === 'r1.2' &&
+            correctedApi.api_name === 'v0.4' && correctedApi.file_name === 'connectivity-insights-subscriptions') {
+          console.error(`Applying correction: ConnectivityInsights r1.2 - mapping 'v0.4' to 'connectivity-insights-subscriptions'`);
+          correctedApi.api_name = 'connectivity-insights-subscriptions';
+        }
+
+        // Fix incorrect title for connectivity-insights-subscriptions in r1.2 and r2.2
+        if (repoName === 'ConnectivityInsights' && (releaseTag === 'r1.2' || releaseTag === 'r2.2') &&
+            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.title === 'Connectivity Insights') {
+          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing title to 'Connectivity Insights Subscriptions'`);
+          correctedApi.title = 'Connectivity Insights Subscriptions';
+        }
+
         // Exclude known invalid RC release
-        if (apiData.api_name === 'region-device-count' && apiData.version === '0.1.0-rc.1') {
-          console.error(`Excluding invalid RC release: ${apiData.api_name} ${apiData.version}`);
+        if (correctedApi.api_name === 'region-device-count' && correctedApi.version === '0.1.0-rc.1') {
+          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.version}`);
           continue;
         }
 
-        // Apply format corrections only (not content changes)
-        const correctedApi = applyFormatCorrections(apiData);
         apis.push(correctedApi);
       }
     } catch (error) {
@@ -264,14 +279,29 @@ async function analyzeGitHubRelease(repository, releaseTag) {
           commonalities: spec.info['x-camara-commonalities'] || null
         };
 
+        // Apply format corrections only (not content changes)
+        const correctedApi = applyFormatCorrections(apiData);
+
+        // Repository/release-specific corrections
+        if (repository === 'ConnectivityInsights' && releaseTag === 'r1.2' &&
+            correctedApi.api_name === 'v0.4' && correctedApi.file_name === 'connectivity-insights-subscriptions') {
+          console.error(`Applying correction: ConnectivityInsights r1.2 - mapping 'v0.4' to 'connectivity-insights-subscriptions'`);
+          correctedApi.api_name = 'connectivity-insights-subscriptions';
+        }
+
+        // Fix incorrect title for connectivity-insights-subscriptions in r1.2 and r2.2
+        if (repository === 'ConnectivityInsights' && (releaseTag === 'r1.2' || releaseTag === 'r2.2') &&
+            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.title === 'Connectivity Insights') {
+          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing title to 'Connectivity Insights Subscriptions'`);
+          correctedApi.title = 'Connectivity Insights Subscriptions';
+        }
+
         // Exclude known invalid RC release
-        if (apiData.api_name === 'region-device-count' && apiData.version === '0.1.0-rc.1') {
-          console.error(`Excluding invalid RC release: ${apiData.api_name} ${apiData.version}`);
+        if (correctedApi.api_name === 'region-device-count' && correctedApi.version === '0.1.0-rc.1') {
+          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.version}`);
           continue;
         }
 
-        // Apply format corrections only (not content changes)
-        const correctedApi = applyFormatCorrections(apiData);
         apis.push(correctedApi);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes duplicate/incomplete API entries and incorrect titles for ConnectivityInsights releases in the Fall24 meta-release data.

## Issues Fixed

### 1. Duplicate "v0.4" Entry (r1.2)
**Problem**: ConnectivityInsights r1.2 shows duplicate entries in fall24.json and Fall24 viewer:
- One correct entry: `connectivity-insights` v0.4.0 with full metadata
- One malformed entry: `v0.4` with null values for portfolio_category, website_url, tooltip

**Root Cause**: The r1.2 release has a malformed server URL in connectivity-insights-subscriptions.yaml:
```yaml
url: "{apiRoot}/connectivity-insights-subscriptions/v0.4/check-network-quality"
```
The extra `/check-network-quality` segment breaks the API name extraction regex, causing it to extract "v0.4" instead of "connectivity-insights-subscriptions".

**Solution**: Add hardcoded correction to map "v0.4" to "connectivity-insights-subscriptions" for r1.2.

### 2. Incorrect Title (r1.2 and r2.2)
**Problem**: The `connectivity-insights-subscriptions` API has incorrect title "Connectivity Insights" instead of "Connectivity Insights Subscriptions" in r1.2 and r2.2.

**Root Cause**: Upstream OpenAPI spec had wrong title. Fixed in r3.2.

**Solution**: Add hardcoded correction to fix title for r1.2 and r2.2.

## Changes

Modified `workflows/release-collector/scripts/analyze-release.js`:
- Added API name correction in `analyzeLocalRelease()` (lines 175-180)
- Added API name correction in `analyzeGitHubRelease()` (lines 270-275)
- Added title correction in `analyzeLocalRelease()` (lines 182-187)
- Added title correction in `analyzeGitHubRelease()` (lines 277-282)

Follows existing pattern for repository-specific corrections (consistent with `region-device-count` exclusion).

## Testing

Tested with analyze-release.js script:
```bash
node workflows/release-collector/scripts/analyze-release.js --github ConnectivityInsights r1.2
node workflows/release-collector/scripts/analyze-release.js --github ConnectivityInsights r2.2
```

Results:
- ✅ r1.2: API name corrected from "v0.4" to "connectivity-insights-subscriptions"
- ✅ r1.2: Title corrected to "Connectivity Insights Subscriptions"
- ✅ r2.2: Title corrected to "Connectivity Insights Subscriptions"
- ✅ r3.2: Unchanged (already correct in upstream)

## Impact

After re-running the release-collector workflow with `analysis_scope: full`:
- fall24.json will no longer contain duplicate/incomplete "v0.4" entry
- Fall24 viewer will show all ConnectivityInsights APIs with correct names and titles
- No impact on other repositories or releases

## Upstream Status

The upstream bugs have been fixed:
- **Server URL bug**: Fixed in r2.1 (September 2025)
- **Title bug**: Fixed in r3.2 (September 2025)

These corrections only affect historical data for r1.2 and r2.2.