### PR TITLE
Enable multi-select category filtering in release collector viewers

### DIFF
--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -654,7 +654,7 @@
     // Global state
     let currentData = null;
     let filteredData = [];
-    let currentCategoryFilter = '';
+    let selectedCategories = [];
     let currentPerspective = 'api';
     let currentSort = { column: -1, ascending: true };
 
@@ -815,25 +815,48 @@
     }
 
     /**
-     * Filter by category
+     * Filter by category (multi-select)
      */
     function filterByCategory(category) {
-      currentCategoryFilter = category;
-
-      const pills = document.querySelectorAll('.category-pill');
-      pills.forEach(pill => pill.classList.remove('active'));
-
       if (category === '') {
-        document.querySelector('.all-categories').classList.add('active');
+        // "All" button - clear all selections
+        selectedCategories = [];
       } else {
-        pills.forEach(pill => {
-          if (pill.textContent.includes(category)) {
-            pill.classList.add('active');
-          }
-        });
+        // Toggle individual category
+        const index = selectedCategories.indexOf(category);
+        if (index > -1) {
+          selectedCategories.splice(index, 1);
+        } else {
+          selectedCategories.push(category);
+        }
       }
 
+      updatePillStates();
       applyFilters();
+    }
+
+    /**
+     * Update pill active states based on selectedCategories
+     */
+    function updatePillStates() {
+      const pills = document.querySelectorAll('.category-pill');
+
+      pills.forEach(pill => {
+        pill.classList.remove('active');
+
+        // "All" is active only when no categories selected
+        if (pill.classList.contains('all-categories')) {
+          if (selectedCategories.length === 0) {
+            pill.classList.add('active');
+          }
+        } else {
+          // Check if this pill's category is selected
+          const pillText = pill.textContent.split('(')[0].trim();
+          if (selectedCategories.includes(pillText)) {
+            pill.classList.add('active');
+          }
+        }
+      });
     }
 
     /**
@@ -849,9 +872,11 @@
       const showUnpublished = document.getElementById('show-unpublished').checked;
 
       filteredData = currentData.apis.filter(api => {
-        // Category filter
-        if (currentCategoryFilter && api.portfolio_category !== currentCategoryFilter) {
-          return false;
+        // Category filter (multi-select with OR logic)
+        if (selectedCategories.length > 0) {
+          if (!selectedCategories.includes(api.portfolio_category)) {
+            return false;
+          }
         }
 
         // Search filter
@@ -899,7 +924,9 @@
       document.getElementById('filterMetaRelease').value = '';
       document.getElementById('filterPublished').value = '';
       document.getElementById('show-unpublished').checked = true;
-      filterByCategory('');
+      selectedCategories = [];
+      updatePillStates();
+      applyFilters();
     }
 
     /**

--- a/workflows/release-collector/templates/meta-release-template.html
+++ b/workflows/release-collector/templates/meta-release-template.html
@@ -107,7 +107,7 @@
     // Global state
     let currentData = null;
     let filteredData = [];
-    let currentCategoryFilter = '';
+    let selectedCategories = [];
     let currentSort = { column: -1, ascending: true };
 
     /**
@@ -279,26 +279,48 @@
     }
 
     /**
-     * Filter by category
+     * Filter by category (multi-select)
      */
     function filterByCategory(category) {
-      currentCategoryFilter = category;
-
-      // Update active state
-      const pills = document.querySelectorAll('.category-pill');
-      pills.forEach(pill => pill.classList.remove('active'));
-
       if (category === '') {
-        document.querySelector('.all-categories').classList.add('active');
+        // "All" button - clear all selections
+        selectedCategories = [];
       } else {
-        pills.forEach(pill => {
-          if (pill.textContent.includes(category)) {
-            pill.classList.add('active');
-          }
-        });
+        // Toggle individual category
+        const index = selectedCategories.indexOf(category);
+        if (index > -1) {
+          selectedCategories.splice(index, 1);
+        } else {
+          selectedCategories.push(category);
+        }
       }
 
+      updatePillStates();
       applyFilters();
+    }
+
+    /**
+     * Update pill active states based on selectedCategories
+     */
+    function updatePillStates() {
+      const pills = document.querySelectorAll('.category-pill');
+
+      pills.forEach(pill => {
+        pill.classList.remove('active');
+
+        // "All" is active only when no categories selected
+        if (pill.classList.contains('all-categories')) {
+          if (selectedCategories.length === 0) {
+            pill.classList.add('active');
+          }
+        } else {
+          // Check if this pill's category is selected
+          const pillText = pill.textContent.split('(')[0].trim();
+          if (selectedCategories.includes(pillText)) {
+            pill.classList.add('active');
+          }
+        }
+      });
     }
 
     /**
@@ -372,9 +394,11 @@
 
       // Filter data
       filteredData = currentData.apis.filter(api => {
-        // Category filter
-        if (currentCategoryFilter && api.portfolio_category !== currentCategoryFilter) {
-          return false;
+        // Category filter (multi-select with OR logic)
+        if (selectedCategories.length > 0) {
+          if (!selectedCategories.includes(api.portfolio_category)) {
+            return false;
+          }
         }
 
         // API Name filter
@@ -435,7 +459,8 @@
       document.getElementById('filterVersion').value = '';
       document.getElementById('filterVersionMin').value = '';
       document.getElementById('filterVersionMax').value = '';
-      filterByCategory(''); // Clear category filter
+      selectedCategories = [];
+      updatePillStates();
 
       applyFilters();
     }

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -298,7 +298,7 @@
     // Global state
     let currentData = null;
     let filteredData = [];
-    let currentCategoryFilter = '';
+    let selectedCategories = [];
     let currentView = 'meta-release';
     let currentSort = { column: -1, ascending: true };
 
@@ -551,26 +551,48 @@
     }
 
     /**
-     * Filter by category
+     * Filter by category (multi-select)
      */
     function filterByCategory(category) {
-      currentCategoryFilter = category;
-
-      // Update active state
-      const pills = document.querySelectorAll('.category-pill');
-      pills.forEach(pill => pill.classList.remove('active'));
-
       if (category === '') {
-        document.querySelector('.all-categories').classList.add('active');
+        // "All" button - clear all selections
+        selectedCategories = [];
       } else {
-        pills.forEach(pill => {
-          if (pill.textContent.includes(category)) {
-            pill.classList.add('active');
-          }
-        });
+        // Toggle individual category
+        const index = selectedCategories.indexOf(category);
+        if (index > -1) {
+          selectedCategories.splice(index, 1);
+        } else {
+          selectedCategories.push(category);
+        }
       }
 
+      updatePillStates();
       applyFilters();
+    }
+
+    /**
+     * Update pill active states based on selectedCategories
+     */
+    function updatePillStates() {
+      const pills = document.querySelectorAll('.category-pill');
+
+      pills.forEach(pill => {
+        pill.classList.remove('active');
+
+        // "All" is active only when no categories selected
+        if (pill.classList.contains('all-categories')) {
+          if (selectedCategories.length === 0) {
+            pill.classList.add('active');
+          }
+        } else {
+          // Check if this pill's category is selected
+          const pillText = pill.textContent.split('(')[0].trim();
+          if (selectedCategories.includes(pillText)) {
+            pill.classList.add('active');
+          }
+        }
+      });
     }
 
     /**
@@ -583,9 +605,11 @@
       const maturityFilter = document.getElementById('filterMaturity').value.toLowerCase();
 
       filteredData = currentData.apis.filter(api => {
-        // Category filter
-        if (currentCategoryFilter && api.portfolio_category !== currentCategoryFilter) {
-          return false;
+        // Category filter (multi-select with OR logic)
+        if (selectedCategories.length > 0) {
+          if (!selectedCategories.includes(api.portfolio_category)) {
+            return false;
+          }
         }
 
         // Search filter (API name or repository)
@@ -613,7 +637,9 @@
     function clearAllFilters() {
       document.getElementById('filterApiName').value = '';
       document.getElementById('filterMaturity').value = '';
-      filterByCategory('');
+      selectedCategories = [];
+      updatePillStates();
+      applyFilters();
     }
 
     /**

--- a/workflows/release-collector/templates/viewer-lib.js
+++ b/workflows/release-collector/templates/viewer-lib.js
@@ -45,9 +45,15 @@ const ViewerLib = {
         return false;
       }
 
-      // Category filter
-      if (criteria.category && api.portfolio_category !== criteria.category) {
-        return false;
+      // Category filter - supports both single and multi-select
+      if (criteria.category) {
+        if (api.portfolio_category !== criteria.category) {
+          return false;
+        }
+      } else if (criteria.categories && criteria.categories.length > 0) {
+        if (!criteria.categories.includes(api.portfolio_category)) {
+          return false;
+        }
       }
 
       // Maturity filter

--- a/workflows/release-collector/templates/viewer-styles.css
+++ b/workflows/release-collector/templates/viewer-styles.css
@@ -135,6 +135,20 @@ body.in-iframe .content {
   border-color: #0092f5;
 }
 
+/* Enhanced active pill styling for multi-select */
+.category-pill.active:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 3px 8px rgba(0, 146, 245, 0.3);
+  opacity: 0.9;
+}
+
+/* Add checkmark indicator for selected pills */
+.category-pill.active::before {
+  content: '✓ ';
+  font-weight: bold;
+  margin-right: 2px;
+}
+
 .category-pill.all-categories {
   background: #6c757d;
   color: white;
@@ -142,6 +156,13 @@ body.in-iframe .content {
 
 .category-pill.all-categories.active {
   background: #5a6268;
+}
+
+/* All pill gets different styling when inactive */
+.category-pill.all-categories:not(.active) {
+  background: white;
+  color: #6c757d;
+  border: 2px solid #6c757d;
 }
 
 .category-count {


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Enables multi-select category filtering in Release Collector viewers, allowing users to select multiple portfolio categories simultaneously and view APIs from all selected categories.

The implementation replaces single-select category filtering with toggle-based multi-select behavior:
- Users can click multiple category pills to select them
- Selected categories show a checkmark indicator
- APIs from any selected category are displayed (OR logic)
- The "All" button clears all selections and shows the full dataset
- Visual feedback indicates which categories are currently selected

This enhancement improves usability for cross-category analysis and API discovery across multiple portfolio categories.

#### Which issue(s) this PR fixes:

Fixes #49

#### Special notes for reviewers:

Changes affect 5 files in the Release Collector workflow:
1. viewer-lib.js - Added backward-compatible multi-category support
2. viewer-styles.css - Added checkmark indicators and enhanced active pill styling
3. meta-release-template.html - Implemented toggle logic and array-based state
4. portfolio-template.html - Same implementation as meta-release template
5. internal-template.html - Same implementation as other templates

The implementation maintains backward compatibility in the shared library (viewer-lib.js) by supporting both single category and multi-category filtering modes.

#### Changelog input

\`\`\`release-note
Enable multi-select category filtering in Release Collector viewers with toggle behavior and visual checkmark indicators
\`\`\`

#### Additional documentation 

\`\`\`docs

\`\`\`