### PR TITLE
Fix viewer counter logic and initialization bug

### DIFF
--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -781,7 +781,7 @@
       `;
 
       buildCategoryPills();
-      renderCurrentView();
+      applyFilters();
     }
 
     /**
@@ -1187,18 +1187,26 @@
     function updateResultsCounter() {
       const counter = document.getElementById('resultsCounter');
       const resultsText = counter.querySelector('.results-text');
-      const total = currentData ? currentData.apis.length : 0;
 
       const count = filteredData.length;
 
       if (count === 0) {
         resultsText.textContent = 'No APIs match the current filters';
         counter.classList.add('no-results');
-      } else if (count === total) {
-        resultsText.textContent = `Showing all ${total} API versions`;
-        counter.classList.remove('no-results');
       } else {
-        resultsText.textContent = `Showing ${count} of ${total} API versions`;
+        // Count unique APIs in displayed data
+        const uniqueCount = ViewerLib.countUniqueAPIs(filteredData);
+
+        let message;
+        if (uniqueCount === count) {
+          // One entry per API
+          message = `Showing ${uniqueCount} APIs`;
+        } else {
+          // Multiple entries for some APIs (different versions/releases)
+          message = `Showing ${uniqueCount} APIs (${count} released versions)`;
+        }
+
+        resultsText.textContent = message;
         counter.classList.remove('no-results');
       }
 

--- a/workflows/release-collector/templates/meta-release-template.html
+++ b/workflows/release-collector/templates/meta-release-template.html
@@ -208,7 +208,7 @@
       populateRepositoryDropdown();
       populateVersionDropdown();
       buildCategoryPills();
-      renderTable(filteredData);
+      applyFilters();
     }
 
     /**
@@ -248,13 +248,14 @@
      * Build category filter pills
      */
     function buildCategoryPills() {
-      const categoryCounts = ViewerLib.getCategoryCounts(currentData.apis);
+      const categoryCounts = ViewerLib.getUniqueCategoryCounts(currentData.apis);
       const pillsContainer = document.getElementById('categoryPills');
 
-      // Update "All" count
+      // Update "All" count with unique API count
       const allPill = pillsContainer.querySelector('.all-categories');
       const allCount = document.getElementById('allCount');
-      allCount.textContent = `(${currentData.apis.length})`;
+      const uniqueTotal = ViewerLib.countUniqueAPIs(currentData.apis);
+      allCount.textContent = `(${uniqueTotal})`;
 
       // Remove existing category pills (keep All pill)
       const existingPills = pillsContainer.querySelectorAll('.category-pill:not(.all-categories)');
@@ -459,24 +460,21 @@
     function updateResultsCounter(count) {
       const counter = document.getElementById('resultsCounter');
       const resultsText = counter.querySelector('.results-text');
-      const total = currentData ? currentData.apis.length : 0;
 
       if (count === 0) {
         resultsText.textContent = 'No APIs match the current filters';
         counter.classList.add('no-results');
-      } else if (count === total) {
-        resultsText.textContent = `Showing all ${total} APIs`;
-        counter.classList.remove('no-results');
       } else {
-        let message = `Showing ${count} of ${total} APIs`;
+        // Count unique APIs in displayed data
+        const uniqueCount = ViewerLib.countUniqueAPIs(filteredData);
 
-        // Add context about filtering mode
-        if (showOnlyLatestPatches) {
-          const allCount = currentData.apis.length;
-          const filteredCount = ViewerLib.filterLatestPatches(currentData.apis).length;
-          if (filteredCount < allCount) {
-            message += ' (latest patches only)';
-          }
+        let message;
+        if (uniqueCount === count) {
+          // One entry per API
+          message = `Showing ${uniqueCount} APIs`;
+        } else {
+          // Multiple entries for some APIs (different versions/releases)
+          message = `Showing ${uniqueCount} APIs (${count} released versions)`;
         }
 
         resultsText.textContent = message;

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -502,36 +502,20 @@
       headerDiv.innerHTML = `API Portfolio across all meta-releases`;
 
       buildCategoryPills();
-      renderCurrentView();
+      applyFilters();
     }
 
     /**
      * Build category filter pills
      */
     function buildCategoryPills() {
-      // Group by unique API names first
-      const uniqueAPIsMap = new Map();
-      currentData.apis.forEach(api => {
-        const key = api.canonical_name || api.api_name;
-        if (!uniqueAPIsMap.has(key)) {
-          // Store first occurrence (has category info)
-          uniqueAPIsMap.set(key, api);
-        }
-      });
-
-      // Count unique APIs per category
-      const categoryCounts = {};
-      uniqueAPIsMap.forEach(api => {
-        const category = api.portfolio_category || 'Other';
-        categoryCounts[category] = (categoryCounts[category] || 0) + 1;
-      });
-
+      const categoryCounts = ViewerLib.getUniqueCategoryCounts(currentData.apis);
       const pillsContainer = document.getElementById('categoryPills');
 
-      // Update "All" count (unique APIs)
-      const uniqueAPIs = uniqueAPIsMap.size;
+      // Update "All" count with unique API count
       const allCount = document.getElementById('allCount');
-      allCount.textContent = `(${uniqueAPIs})`;
+      const uniqueTotal = ViewerLib.countUniqueAPIs(currentData.apis);
+      allCount.textContent = `(${uniqueTotal})`;
 
       // Remove existing category pills (keep All pill)
       const existingPills = pillsContainer.querySelectorAll('.category-pill:not(.all-categories)');
@@ -907,17 +891,25 @@
       const counter = document.getElementById('resultsCounter');
       const resultsText = counter.querySelector('.results-text');
 
-      const uniqueFiltered = new Set(filteredData.map(a => a.canonical_name || a.api_name)).size;
-      const uniqueTotal = new Set(currentData.apis.map(a => a.canonical_name || a.api_name)).size;
+      const count = filteredData.length;
 
-      if (uniqueFiltered === 0) {
+      if (count === 0) {
         resultsText.textContent = 'No APIs match the current filters';
         counter.classList.add('no-results');
-      } else if (uniqueFiltered === uniqueTotal) {
-        resultsText.textContent = `Showing all ${uniqueTotal} APIs`;
-        counter.classList.remove('no-results');
       } else {
-        resultsText.textContent = `Showing ${uniqueFiltered} of ${uniqueTotal} APIs`;
+        // Count unique APIs in displayed data
+        const uniqueCount = ViewerLib.countUniqueAPIs(filteredData);
+
+        let message;
+        if (uniqueCount === count) {
+          // One entry per API
+          message = `Showing ${uniqueCount} APIs`;
+        } else {
+          // Multiple entries for some APIs (different versions/releases)
+          message = `Showing ${uniqueCount} APIs (${count} released versions)`;
+        }
+
+        resultsText.textContent = message;
         counter.classList.remove('no-results');
       }
 

--- a/workflows/release-collector/templates/viewer-lib.js
+++ b/workflows/release-collector/templates/viewer-lib.js
@@ -336,6 +336,47 @@ const ViewerLib = {
   },
 
   /**
+   * Count unique APIs in a dataset (by canonical_name or api_name)
+   * @param {Array} apis - Array of API objects
+   * @returns {number} Count of unique APIs
+   */
+  countUniqueAPIs: function(apis) {
+    const uniqueNames = new Set();
+    apis.forEach(api => {
+      const key = api.canonical_name || api.api_name;
+      uniqueNames.add(key);
+    });
+    return uniqueNames.size;
+  },
+
+  /**
+   * Get unique API counts per category
+   * @param {Array} apis - Array of API objects
+   * @returns {Object} Category counts based on unique APIs
+   */
+  getUniqueCategoryCounts: function(apis) {
+    const categoryApis = {}; // Track unique APIs per category
+
+    apis.forEach(api => {
+      const category = api.portfolio_category || 'Other';
+      const apiKey = api.canonical_name || api.api_name;
+
+      if (!categoryApis[category]) {
+        categoryApis[category] = new Set();
+      }
+      categoryApis[category].add(apiKey);
+    });
+
+    // Convert Sets to counts
+    const counts = {};
+    Object.keys(categoryApis).forEach(category => {
+      counts[category] = categoryApis[category].size;
+    });
+
+    return counts;
+  },
+
+  /**
    * Get unique values for a field
    * @param {Array} apis - Array of APIs
    * @param {string} field - Field name


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes two bugs introduced in PR #54:

1. **Counter Logic Bug**: Added `countUniqueAPIs()` and `getUniqueCategoryCounts()` utilities to properly count unique APIs instead of release entries. Updated counter messaging to show "X APIs" or "X APIs (Y released versions)" as appropriate. Category pills now also show unique API counts.

2. **Initialization Bug**: Fixed `displayData()` function in all templates to call `applyFilters()` instead of rendering directly, ensuring filters (including patch filter) are applied on page load.

**Files Modified**:
- workflows/release-collector/templates/viewer-lib.js
- workflows/release-collector/templates/meta-release-template.html
- workflows/release-collector/templates/portfolio-template.html
- workflows/release-collector/templates/internal-template.html

#### Which issue(s) this PR fixes:

Fixes #58

#### Special notes for reviewers:

- Both bugs affect all three viewer types (meta-release, portfolio, internal)
- Changes are backwards compatible
- Counter now correctly distinguishes between unique APIs and release entries
- Filter initialization now works consistently with checkbox default state

#### Changelog input

```release-note
Fix viewer counter to show unique API count and fix filter initialization
```

#### Additional documentation

This section can be blank.

```docs

```