### PR TITLE
fix: Use inline defaults for job-level if conditions

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -288,7 +288,7 @@ jobs:
       always() &&
       (needs.update-metadata.result == 'success' ||
        needs.detect-releases.outputs.templates_changed == 'true' ||
-       env.FORCE_VIEWERS == 'true')
+       (github.event.inputs.force_viewers || 'false') == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -334,7 +334,7 @@ jobs:
   publish-changes:
     name: Publish Changes
     needs: generate-viewers
-    if: env.EXECUTION_MODE != 'dry-run'
+    if: (github.event.inputs.execution_mode || 'pr') != 'dry-run'
     runs-on: ubuntu-latest
     outputs:
       pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
@@ -493,7 +493,7 @@ jobs:
     needs: generate-viewers
     if: |
       always() &&
-      env.EXECUTION_MODE == 'pr' &&
+      (github.event.inputs.execution_mode || 'pr') == 'pr' &&
       needs.generate-viewers.result == 'success'
     permissions:
       contents: read


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes GitHub Actions workflow validation error for job-level `if:` conditions.

Job-level `if:` expressions cannot access the `env` context in GitHub Actions, even when env vars are defined at workflow level. This caused the workflow to fail validation after merging PR #81:

```
Invalid workflow file: .github/workflows/release-collector.yml#L1
Unrecognized named-value: 'env'
```

This PR moves defaults inline for the three affected job conditions:
- `generate-viewers`: `(github.event.inputs.force_viewers || 'false') == 'true'`
- `publish-changes`: `(github.event.inputs.execution_mode || 'pr') != 'dry-run'`
- `deploy-staging`: `(github.event.inputs.execution_mode || 'pr') == 'pr'`

Step-level `if:` conditions continue using `env.*` which works at runtime.

#### Which issue(s) this PR fixes:

Follow-up fix for #75 (fixes workflow validation error from PR #81)

#### Special notes for reviewers:

GitHub Actions context availability:
- **Job-level `if:`** - Only `github`, `needs`, `vars`, `secrets` contexts available
- **Step-level `if:` and `run:`** - Full context including `env` available at runtime

The `||` operator provides fallback defaults when inputs are empty (scheduled runs).

#### Changelog input

```
release-note
Fix workflow validation error for job-level if conditions
```

#### Additional documentation

This section can be blank.

```
docs

```