### PR TITLE
fix: internal viewer debug shows correct data for each API version

### DIFF
--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -1046,7 +1046,7 @@
           <td>${api.published ? '✓' : '✗'}</td>
           <td>${api.portfolio_category || '<em>Missing</em>'}</td>
           <td>${api.first_release || '-'}</td>
-          <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)})'>🔍</button></td>
+          <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
         `;
 
         tbody.appendChild(row);
@@ -1143,8 +1143,12 @@
     /**
      * Show debug modal for specific API
      */
-    function showDebug(apiName) {
-      const api = filteredData.find(a => a.api_name === apiName);
+    function showDebug(apiName, version, releaseTag) {
+      const api = filteredData.find(a =>
+        a.api_name === apiName &&
+        a.version === version &&
+        a.release_tag === releaseTag
+      );
       if (!api) return;
 
       const modal = document.getElementById('debug-modal');


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes the internal viewer debug button showing wrong data when an API has multiple versions/releases.

The `showDebug()` function was using only `api_name` to find the entry, but `Array.find()` returns the first match. When multiple entries share the same `api_name` (different versions/releases), clicking debug on any version would show the first (oldest) entry's data.

The fix passes `api_name`, `version`, and `release_tag` to uniquely identify each API entry.

#### Which issue(s) this PR fixes:

Fixes #83

#### Special notes for reviewers:

Two small changes in `internal-template.html`:
- Line 1049: Button onclick now passes version and release_tag
- Lines 1146-1151: `showDebug()` now matches on all three fields

#### Changelog input

```
release-note
fix: internal viewer debug button now shows correct data for each API version
```

#### Additional documentation 

This section can be blank.

```
docs

```