### PR TITLE
Release Collector: fix production workflow summary to reflect validation failures

### DIFF
--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -148,11 +148,16 @@ jobs:
 
           # Compare timestamps (ISO format allows string comparison)
           if [[ "$STAGING_TIMESTAMP" > "$MAIN_TIMESTAMP" ]]; then
-            echo "::error::Staging has newer content ($STAGING_TIMESTAMP) than main ($MAIN_TIMESTAMP)"
-            echo "::error::This suggests a PR has not been merged yet."
-            echo "::error::Either merge the pending PR first, or use 'ref' parameter to deploy specific commit."
+            MSG="Staging has newer content ($STAGING_TIMESTAMP) than main ($MAIN_TIMESTAMP). Merge the pending PR first, or use 'ref' parameter to deploy specific commit."
             echo "skip_deploy=true" >> $GITHUB_OUTPUT
-            exit 1
+
+            if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+              echo "::warning::$MSG"
+              # Don't fail in dry-run - just report the issue
+            else
+              echo "::error::$MSG"
+              exit 1
+            fi
           fi
 
           echo "Timestamp check passed: main ($MAIN_TIMESTAMP) >= staging ($STAGING_TIMESTAMP)"
@@ -361,8 +366,16 @@ jobs:
           DEPLOY_SHA="${{ needs.validate-deployment.outputs.deploy_sha }}"
           MAIN_TS="${{ needs.validate-deployment.outputs.main_timestamp }}"
           STAGING_TS="${{ needs.validate-deployment.outputs.staging_timestamp }}"
+          SKIP_DEPLOY="${{ needs.validate-deployment.outputs.skip_deploy }}"
+          VALIDATION_RESULT="${{ needs.validate-deployment.result }}"
           DEPLOYED="${{ needs.deploy-production.outputs.deployed }}"
           COMMIT_URL="${{ needs.deploy-production.outputs.commit_url }}"
+
+          # Determine if validation failed (job failed or skip_deploy set)
+          VALIDATION_FAILED="false"
+          if [[ "$VALIDATION_RESULT" != "success" || "$SKIP_DEPLOY" == "true" ]]; then
+            VALIDATION_FAILED="true"
+          fi
 
           echo "## Release Collector - Production Deployment" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -401,7 +414,11 @@ jobs:
             else
               echo "- Main: $MAIN_TS" >> $GITHUB_STEP_SUMMARY
               echo "- Staging: $STAGING_TS" >> $GITHUB_STEP_SUMMARY
-              echo "- Status: ✓ Safe to deploy" >> $GITHUB_STEP_SUMMARY
+              if [[ "$VALIDATION_FAILED" == "true" ]]; then
+                echo "- Status: ❌ Validation failed - staging has newer content than main" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- Status: ✓ Safe to deploy" >> $GITHUB_STEP_SUMMARY
+              fi
             fi
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
@@ -419,7 +436,11 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Deployment result
-          if [[ "$DRY_RUN" == "true" ]]; then
+          if [[ "$VALIDATION_FAILED" == "true" ]]; then
+            echo "### Validation Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Deployment blocked. Merge the pending PR first, then re-run this workflow." >> $GITHUB_STEP_SUMMARY
+          elif [[ "$DRY_RUN" == "true" ]]; then
             echo "### Dry Run Complete" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Validation passed. Re-run without dry_run to deploy to production." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes the production deployment workflow summary to correctly reflect validation failures instead of showing misleading success messages.

Changes:
1. Consolidate three `::error::` annotations into one clear message
2. In dry-run mode, use `::warning::` and don't fail the workflow (dry-run is for previewing, not blocking)
3. Summary job checks both `needs.validate-deployment.result` and `skip_deploy` output
4. Show appropriate status: "❌ Validation failed" vs "✓ Safe to deploy"

#### Which issue(s) this PR fixes:

Fixes #87

#### Special notes for reviewers:

Expected behavior after this fix:
1. Production mode with timestamp mismatch: Workflow FAILS, shows "❌ Validation failed"
2. Dry-run mode with timestamp mismatch: Workflow SUCCEEDS (green), shows "❌ Validation failed", warning annotation
3. Dry-run mode with valid timestamps: Workflow SUCCEEDS, shows "✓ Safe to deploy", "Dry Run Complete"
4. Production mode with valid timestamps: Workflow SUCCEEDS, shows "✓ Safe to deploy", "Deployment Complete"

#### Changelog input

```
release-note
Fix production workflow summary to reflect validation failures correctly
```

#### Additional documentation

This section can be blank.

```
docs

```