### PR TITLE
Release Collector: fix dry-run validation failure overwrites skip_deploy

### DIFF
--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -158,10 +158,10 @@ jobs:
               echo "::error::$MSG"
               exit 1
             fi
+          else
+            echo "Timestamp check passed: main ($MAIN_TIMESTAMP) >= staging ($STAGING_TIMESTAMP)"
+            echo "skip_deploy=false" >> $GITHUB_OUTPUT
           fi
-
-          echo "Timestamp check passed: main ($MAIN_TIMESTAMP) >= staging ($STAGING_TIMESTAMP)"
-          echo "skip_deploy=false" >> $GITHUB_OUTPUT
 
       - name: Validation summary
         run: |
@@ -186,6 +186,7 @@ jobs:
   generate-viewers:
     name: Generate Viewers
     needs: validate-deployment
+    if: needs.validate-deployment.outputs.skip_deploy != 'true'
     runs-on: ubuntu-latest
     outputs:
       viewers_generated: ${{ steps.generate.outputs.success }}


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Follow-up fix for #87. In dry-run mode with validation failure (staging > main timestamp):
1. `skip_deploy=true` was set correctly
2. But then code continued and overwrote it with `skip_deploy=false`
3. Viewer generation still ran when it shouldn't

Changes:
1. Move `skip_deploy=false` and "Timestamp check passed" to else branch so they only execute when validation passes
2. Add condition to generate-viewers job to skip when `skip_deploy=true`

#### Which issue(s) this PR fixes:

Follow-up to #87 (discovered during testing of #88)

#### Special notes for reviewers:

After this fix, dry-run with timestamp mismatch will:
- Show "❌ Validation failed" in summary (correctly)
- Skip viewer generation entirely
- Complete with green checkmark

#### Changelog input

```
release-note
Fix dry-run validation to preserve skip_deploy flag and skip viewer generation
```

#### Additional documentation

This section can be blank.

```
docs

```