### PR TITLE
Release Collector: hide 'Files Deployed' section when validation fails

### DIFF
--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -424,17 +424,19 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Files deployed
-          echo "### Files Deployed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| File | Description |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|-------------|" >> $GITHUB_STEP_SUMMARY
-          echo "| index.html | Production entry page |" >> $GITHUB_STEP_SUMMARY
-          echo "| fall24.html | Fall 2024 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
-          echo "| spring25.html | Spring 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
-          echo "| fall25.html | Fall 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
-          echo "| portfolio.html | Portfolio overview |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          # Files deployed (only show when validation passed)
+          if [[ "$VALIDATION_FAILED" != "true" ]]; then
+            echo "### Files Deployed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| File | Description |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-------------|" >> $GITHUB_STEP_SUMMARY
+            echo "| index.html | Production entry page |" >> $GITHUB_STEP_SUMMARY
+            echo "| fall24.html | Fall 2024 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
+            echo "| spring25.html | Spring 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
+            echo "| fall25.html | Fall 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
+            echo "| portfolio.html | Portfolio overview |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # Deployment result
           if [[ "$VALIDATION_FAILED" == "true" ]]; then


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Follow-up fix for #87. The "Files Deployed" section was showing unconditionally, even when validation failed and no files were deployed.

Now the section only shows when `VALIDATION_FAILED != "true"`.

#### Which issue(s) this PR fixes:

Follow-up to #87 (discovered during testing of #89)

#### Special notes for reviewers:

Simple one-liner: wrap the "Files Deployed" section in a condition.

#### Changelog input

```
release-note
Hide 'Files Deployed' section in summary when validation fails
```

#### Additional documentation

This section can be blank.

```
docs

```