### PR TITLE
Prepare r1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,56 @@
 
 ## Table of Contents
 
+- **[r1.3](#r13)**
 - **[r1.2](#r12)**
 - **[r1.1](#r11)**
+
+## r1.3
+
+**Release focus: Release Plan Rollout campaign and extended Release Collector**
+
+### Added
+
+* **Release Plan Rollout campaign** (`campaign-release-plan-rollout.yml`)
+  - Adds release-plan.yaml to all CAMARA API repositories
+  - Supports dry-run mode for planning before execution
+  - Handles repositories with releases, WIP repositories, and new repositories
+  - Includes validation step and comprehensive error handling
+  - Mustache templates for release-plan generation
+
+* **Pre-release tracking** in Release Collector
+  - Extended to track pre-releases with repositories array filter
+  - Added release type filtering to portfolio and internal viewers
+  - Filter visibility for r0.X releases
+
+* **Release-metadata generation** with schema 2.0.0
+  - New property naming conventions
+  - Enhanced dry-run analysis for metadata upload
+
+* **Theme toggle** for viewers embedded in iframes
+
+* **Dependabot** for automated GitHub Actions updates
+
+### Changed
+
+* Aligned filter terminology with release-plan-schema conventions
+* Updated GitHub Actions to latest versions
+* Improved template formatting (ASCII characters for compatibility)
+
+### Fixed
+
+* Fixed release-collector creating empty PRs daily (#106)
+* Fixed release_type visibility in viewers
+* Fixed maintenance-release branch naming convention in README
+* Fixed aggregate job to run in both dry-run and apply modes
+
+### Documentation
+
+* Comprehensive documentation for pre-releases, metadata generation, and production upload
+* Updated release-collector QUICKSTART and README
+* New documentation for release-plan-rollout campaign
+
+---
 
 ## r1.2
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Goal-oriented, time-bound initiatives for coordinated changes across repositorie
 * **Available campaigns**:
   * [release-info/](campaigns/release-info/) - Updates "Release Information" sections in API repository READMEs
   * [api-version-wip-check/](campaigns/api-version-wip-check/) - Verifies wip versions in API files after releases
-* **Workflows**: `campaign-release-info.yml`, `campaign-api-version-wip-check.yml`
+  * [release-plan-rollout/](campaigns/release-plan-rollout/) - Adds release-plan.yaml to API repositories
+* **Workflows**: `campaign-release-info.yml`, `campaign-api-version-wip-check.yml`, `campaign-release-plan-rollout.yml`
 
 ### API Repository Creation
 
@@ -101,7 +102,8 @@ project-administration/
 ├── actions/                     # Reusable GitHub Actions for campaigns
 ├── campaigns/                   # Goal-oriented initiatives
 │   ├── api-version-wip-check/   # API version compliance checks
-│   └── release-info/            # README release info updates
+│   ├── release-info/            # README release info updates
+│   └── release-plan-rollout/    # Release plan file generation
 ├── config/                      # Shared configuration files
 │   ├── api-landscape.yaml       # API portfolio metadata
 │   └── meta-release-mappings.yaml

--- a/actions/campaign-finalize-issue-per-repo/action.yml
+++ b/actions/campaign-finalize-issue-per-repo/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Campaign Finalize Issue Per Repo
+#
+# Generic finalization for issue-based campaign workflows. Handles issue creation,
+# deduplication, recording, and artifact upload.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: 'Campaign Finalize Issue Per Repo'
 description: 'Generic finalization for issue-based campaign workflows: issue creation, deduplication, record, upload'
 inputs:

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Campaign Finalize Per Repo
+#
+# Generic finalization for PR-based campaign workflows. Handles commit, push,
+# PR creation, duplicate detection, and artifact upload.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: 'Campaign Finalize Per Repo'
 description: 'Generic finalization for campaign workflows: commit, PR, record, upload'
 inputs:

--- a/actions/ensure-delimited-section/action.yml
+++ b/actions/ensure-delimited-section/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Ensure Delimited Section
+#
+# Ensures a delimited section exists in a file (idempotent operation).
+# Creates placeholder section if missing, used before content replacement.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: ensure-delimited-section
 description: Ensure a delimited section exists in a file (idempotent)
 inputs:

--- a/actions/read-api-version-compliance/action.yml
+++ b/actions/read-api-version-compliance/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Read API Version Compliance
+#
+# Checks API version compliance in OpenAPI YAML and Gherkin test files.
+# Verifies that main branch uses "wip" versions after releases.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: read-api-version-compliance
 description: Check API version compliance (wip versions) in OpenAPI YAML and Gherkin test files
 inputs:

--- a/actions/read-release-data/action.yml
+++ b/actions/read-release-data/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Read Release Data
+#
+# Resolves repository release data (latest public release, API version) from
+# releases-master.yaml for use in campaign workflows and templates.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: read-release-data
 description: Resolve repo data (latest public release, api version) from releases-master.yaml
 inputs:

--- a/actions/render-mustache/action.yml
+++ b/actions/render-mustache/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Render Mustache
+#
+# Renders a Mustache template with JSON data and writes output to a file.
+# Used by campaign workflows to generate PR/issue bodies from templates.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: render-mustache
 description: Render a mustache template with JSON data
 inputs:

--- a/actions/replace-delimited-content/action.yml
+++ b/actions/replace-delimited-content/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Replace Delimited Content
+#
+# Replaces content between start/end delimiters in a file with new content.
+# Used to update auto-generated sections in README files.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: replace-delimited-content
 description: Replace content between delimiters in a file
 inputs:

--- a/campaigns/release-plan-rollout/actions/generate-release-plan/action.yml
+++ b/campaigns/release-plan-rollout/actions/generate-release-plan/action.yml
@@ -1,3 +1,12 @@
+# =========================================================================================
+# CAMARA Project - Action: Generate Release Plan
+#
+# Generates release-plan.yaml from releases-master.yaml data using Mustache templates.
+# Part of the Release Plan Rollout campaign for standardizing release planning files.
+#
+# CHANGELOG:
+# - 2026-01-27: Added standardized header for r1.3 release
+# =========================================================================================
 name: generate-release-plan
 description: Generate release-plan.yaml from releases-master.yaml data using Mustache templates
 inputs:


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Prepares the r1.3 release of project-administration with:
- CHANGELOG update documenting all changes since r1.2 (37 commits)
- README update to include the new release-plan-rollout campaign
- Standardized headers added to all 8 reusable action files

#### Which issue(s) this PR fixes:

N/A - Release preparation

#### Special notes for reviewers:

This is a release preparation PR. The r1.3 release includes:
- **Release Plan Rollout campaign** - New campaign for adding release-plan.yaml to API repositories
- **Extended Release Collector** - Pre-release tracking, release type filtering, metadata generation with schema 2.0.0
- **Bug fixes** - Empty daily PR creation (#106), release_type visibility, aggregate job modes
- **Infrastructure** - Dependabot for GitHub Actions updates

#### Changelog input

```
release-note
See CHANGELOG.md r1.3 section for full release notes
```

#### Additional documentation 

```
docs
- CHANGELOG.md updated with r1.3 section
- README.md updated with release-plan-rollout campaign
- All action files now have standardized headers
```