### PR TITLE
Fix release-collector not adding new releases to master data

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -241,11 +241,14 @@ jobs:
 
           echo "Analysis complete for group"
 
+      - name: Prepare analysis results for upload
+        run: cp temp/analysis-results.json temp/analysis-results-${{ strategy.job-index }}.json
+
       - name: Upload analysis results
         uses: actions/upload-artifact@v6
         with:
           name: analysis-group-${{ strategy.job-index }}
-          path: temp/analysis-results.json
+          path: temp/analysis-results-${{ strategy.job-index }}.json
 
   # =========================================================================================
   # Phase 3: Data Processing
@@ -285,7 +288,8 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: analysis-group-*
-          path: temp/
+          path: temp/analysis-downloads/
+          merge-multiple: true
 
       - name: Combine and process data
         run: |
@@ -296,7 +300,7 @@ jobs:
 
           # Combine all analysis results
           echo '[]' > temp/combined-analysis.json
-          for file in temp/analysis-group-*/analysis-results.json; do
+          for file in temp/analysis-downloads/analysis-results-*.json; do
             if [[ -f "$file" ]]; then
               jq -s '.[0] + .[1]' temp/combined-analysis.json "$file" > temp/combined-updated.json
               mv temp/combined-updated.json temp/combined-analysis.json


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The download-artifact v4→v7 upgrade (c8de83ef) changed extraction behavior when a pattern matches a single artifact: files are extracted directly into the target path instead of a named subdirectory. During incremental runs with one analysis group, the glob `temp/analysis-group-*/analysis-results.json` found no matches, so `update-master.js` received empty input and wrote unchanged data. Affected since run #73 (Feb 6).

Fix: use `merge-multiple` with uniquely-named files per analysis group so the combine glob works regardless of artifact count.

#### Which issue(s) this PR fixes:

Fixes #123

#### Special notes for reviewers:

The 5 open PRs (#115-#122) created by broken runs contain only timestamp changes and should be closed after this is merged.

#### Changelog input

```
 release-note
Fix release-collector artifact download after download-artifact v7 upgrade
```

#### Additional documentation 

This section can be blank.

```
docs

```