### PR TITLE
Remove 'none' option from release_track in campaign templates

### DIFF
--- a/campaigns/release-plan-rollout/README.md
+++ b/campaigns/release-plan-rollout/README.md
@@ -76,7 +76,7 @@ For WIP and new repositories, the campaign generates a **placeholder** with defa
 
 ```yaml
 repository:
-  release_track: "none"
+  release_track: "independent"
   target_release_tag: "r1.1"
   target_release_type: "none"
 apis: []

--- a/campaigns/release-plan-rollout/templates/release-plan-no-releases.mustache
+++ b/campaigns/release-plan-rollout/templates/release-plan-no-releases.mustache
@@ -7,7 +7,7 @@
 
 repository:
   # How this repository participates in CAMARA releases
-  # Options: none | independent | meta-release
+  # Options: independent (default) | meta-release
   release_track: independent
 
   # Uncomment and set when planning a meta-release participation:

--- a/campaigns/release-plan-rollout/templates/release-plan-with-releases.mustache
+++ b/campaigns/release-plan-rollout/templates/release-plan-with-releases.mustache
@@ -7,7 +7,7 @@
 
 repository:
   # How this repository participates in CAMARA releases
-  # Options: none | independent | meta-release
+  # Options: independent (default) | meta-release
   release_track: {{release_track}}
   {{#meta_release}}
   # Meta-release participation (update for next cycle when planning)


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Aligns the release-plan-rollout campaign templates and documentation with ReleaseManagement#375 (PR ReleaseManagement#377), which removed the redundant `none` option from `release_track`. The `none` value was behaviorally identical to `independent` and created confusion.

Changes:
- `campaigns/release-plan-rollout/templates/release-plan-with-releases.mustache`: Updated options comment
- `campaigns/release-plan-rollout/templates/release-plan-no-releases.mustache`: Updated options comment
- `campaigns/release-plan-rollout/README.md`: Updated placeholder example to use `independent`

#### Which issue(s) this PR fixes:

Fixes #127

#### Special notes for reviewers:

The authoritative schema change was already merged in ReleaseManagement#377. This PR propagates the same change to the campaign templates and documentation.

#### Changelog input

```
 release-note
Remove 'none' option from release_track in campaign templates, aligning with ReleaseManagement schema update
```

#### Additional documentation 

This section can be blank.

```
docs

```