### PR TITLE
feat: include superseded pre-releases in master metadata

### DIFF
--- a/workflows/release-collector/scripts/detect-releases.js
+++ b/workflows/release-collector/scripts/detect-releases.js
@@ -152,7 +152,6 @@ function findNewReleases(repoReleases, storedReleases, mode) {
   );
 
   const newReleases = [];
-  let skippedSuperseded = 0;
 
   for (const releaseInfo of repoReleases) {
     const key = `${releaseInfo.repository}:${releaseInfo.release_tag}`;
@@ -160,20 +159,14 @@ function findNewReleases(repoReleases, storedReleases, mode) {
     // Skip if already in master
     if (storedTags.has(key)) continue;
 
-    // In incremental mode, skip superseded pre-releases
+    // Log superseded pre-releases (but still include them for metadata generation)
     if (mode === 'incremental' && releaseInfo.is_prerelease) {
       if (isSupersededPrerelease(releaseInfo, storedReleases)) {
-        console.error(`  Skipped (superseded): ${releaseInfo.repository} ${releaseInfo.release_tag}`);
-        skippedSuperseded++;
-        continue;
+        console.error(`  New (superseded): ${releaseInfo.repository} ${releaseInfo.release_tag}`);
       }
     }
 
     newReleases.push(releaseInfo);
-  }
-
-  if (skippedSuperseded > 0) {
-    console.error(`Skipped ${skippedSuperseded} superseded pre-releases`);
   }
 
   return newReleases;


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Previously, the Release Collector removed superseded pre-releases from `releases-master.yaml` entirely. This meant no `release-metadata.yaml` files were generated for these releases, and the Production Deploy could not upload metadata to the corresponding API repository GitHub releases.

This is needed for Release Automation integration: `version_calculator.py` reads `release-metadata.yaml` from API repository releases to find existing URL version extensions (e.g., `v1rc1`, `v1rc2`). For stable APIs (major >= 1), URL versions like `v1rcN` share the same namespace across minor versions, so all legacy pre-release extensions must be visible to avoid assigning duplicate extension numbers.

**Changes:**

- **detect-releases.js**: Superseded pre-releases are now logged but still included for analysis (previously skipped with `continue`)
- **update-master.js**: Superseded pre-releases are marked with `superseded: true` instead of being removed. Includes retroactive marking when a new public release supersedes existing pre-releases. `computeRepoReleaseRefs` excludes superseded from `newest_pre_release`
- **generate-reports.js**: Filters out superseded releases before report generation, keeping reports and viewers unchanged

**Data flow**: Superseded pre-releases stay in `releases-master.yaml` → `generate-release-metadata.js` generates their metadata files → Production Deploy uploads them to API repos → `version_calculator.py` can find legacy extensions.

Reports, viewers, and all external-facing outputs remain unchanged.

#### Which issue(s) this PR fixes:

Fixes #118

#### Special notes for reviewers:

Tested on fork (`hdamker/project-administration`) with:
1. Full analysis run: 173 releases (89 active + 84 superseded), all metadata files generated, zero superseded in any report
2. Incremental run: correctly detected 0 new releases (all 173 already in master)

The `superseded` field is only present when `true` (uses `superseded || undefined` pattern) to keep YAML clean.

#### Changelog input

```
 release-note
Include superseded pre-releases in master metadata for release-metadata generation
```

#### Additional documentation 

This section can be blank.

```
docs

```