### PR TITLE
Fix release-plan rollout campaign for production use

### DIFF
--- a/.github/workflows/campaign-release-plan-rollout.yml
+++ b/.github/workflows/campaign-release-plan-rollout.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: ''
+      exclude:
+        description: 'Comma-separated list of repository names to exclude (e.g., "Template_API_Repository, Sandbox")'
+        required: false
+        type: string
+        default: ''
       include_wip_repos:
         description: 'Include repositories without release but with API definition files (work in progress, require manual review)'
         required: false
@@ -48,6 +53,7 @@ env:
   ORG: camaraproject
   RELEASES_FILE: data/releases-master.yaml
   INCLUDE: ${{ inputs.include }}
+  EXCLUDE: ${{ inputs.exclude }}
   INCLUDE_WIP_REPOS: ${{ inputs.include_wip_repos }}
   INCLUDE_NEW_REPOS: ${{ inputs.include_new_repos }}
   BRANCH: bulk/release-plan-rollout-${{ github.run_id }}
@@ -101,6 +107,13 @@ jobs:
               console.log(`Include filter applied: ${include.join(', ')}`);
             }
 
+            // Apply exclude filter if specified
+            const exclude = (process.env.EXCLUDE||'').split(',').map(s=>s.trim()).filter(Boolean);
+            if (exclude.length) {
+              list = list.filter(r => !exclude.some(x => r.slug.endsWith(`/${x}`)));
+              console.log(`Exclude filter applied: ${exclude.join(', ')}`);
+            }
+
             console.log(`Found ${list.length} repositories after filtering`);
 
             // For repos without releases, check if they have API files
@@ -130,7 +143,7 @@ jobs:
 
             console.log(`\nInput settings: include_wip_repos=${includeWip}, include_new_repos=${includeNew}`);
 
-            const counts = { withRelease: 0, wip: 0, new: 0, skippedWip: 0, skippedNew: 0, skippedExists: 0 };
+            const counts = { withRelease: 0, wip: 0, new: 0, skippedWip: 0, skippedNew: 0, skippedExists: 0, skippedExclude: 0 };
             const filteredList = [];
 
             for (const repo of list) {
@@ -183,6 +196,7 @@ jobs:
             console.log(`  - New repos: ${counts.new}`);
             console.log(`Skipped:`);
             console.log(`  - Already have release-plan.yaml: ${counts.skippedExists}`);
+            if (exclude.length) console.log(`  - Excluded by exclude filter: ${exclude.length}`);
             console.log(`  - WIP repos excluded: ${counts.skippedWip}`);
             console.log(`  - New repos excluded: ${counts.skippedNew}`);
 
@@ -250,11 +264,10 @@ jobs:
           data_json: ${{ steps.generate.outputs.json }}
           out_file: /tmp/pr-body.md
 
-      # TODO: Change to camaraproject/tooling@v0 when shared-action is released
       - name: Validate generated release-plan.yaml
         id: validate
         continue-on-error: true
-        uses: hdamker/tooling/shared-actions/validate-release-plan@release-plan-validation
+        uses: camaraproject/tooling/shared-actions/validate-release-plan@v0
         with:
           release_plan_path: repo/release-plan.yaml
 

--- a/campaigns/release-plan-rollout/templates/pr-body-no-releases.mustache
+++ b/campaigns/release-plan-rollout/templates/pr-body-no-releases.mustache
@@ -9,6 +9,8 @@ The `release-plan.yaml` file declares your release intentions. It enables:
 - **CI validation** of release readiness
 - **Automated release branch creation** (coming soon)
 
+> **Note:** Adding `release-plan.yaml` is a prerequisite for the planned release automation. This does not yet enable the automated release workflow -- onboarding will follow separately.
+
 ### Pre-populated data
 
 - **Contacts**: From your CODEOWNERS file

--- a/campaigns/release-plan-rollout/templates/pr-body-with-releases.mustache
+++ b/campaigns/release-plan-rollout/templates/pr-body-with-releases.mustache
@@ -9,6 +9,8 @@ The `release-plan.yaml` file declares your release intentions for this repositor
 - **CI validation** of release readiness
 - **Automated release branch creation** (coming soon)
 
+> **Note:** Adding `release-plan.yaml` is a prerequisite for the planned release automation. This does not yet enable the automated release workflow -- onboarding will follow separately.
+
 ### Pre-populated data
 
 This file was generated from your latest release data and repository settings:


### PR DESCRIPTION
**Problem description**

Fixes #135

Three fixes to prepare the release-plan rollout campaign for production use:

1. **Fix validation action reference** -- the workflow referenced `hdamker/tooling@release-plan-validation` which doesn't resolve; updated to `camaraproject/tooling@v0`
2. **Add prerequisite note to PR templates** -- clarifies that adding `release-plan.yaml` is a prerequisite for release automation, not the actual onboarding
3. **Add exclude input** -- comma-separated list of repository names to skip during rollout

Dry-run tested successfully against QualityOnDemand.

Related to camaraproject/ReleaseManagement#357.