### PR TITLE
Fix single-artifact aggregate in release-info and wip-check campaigns

### DIFF
--- a/.github/workflows/campaign-api-version-wip-check.yml
+++ b/.github/workflows/campaign-api-version-wip-check.yml
@@ -253,9 +253,9 @@ jobs:
 
             const md = [];
             const lines = [];
-            const dirs = fs.readdirSync(p);
+            const entries = fs.readdirSync(p);
 
-            if (dirs.length === 0) {
+            if (entries.length === 0) {
               console.log(`${p} directory is empty, no artifacts were downloaded`);
               fs.writeFileSync(`${outputName}.md`, `# No ${outputName} artifacts found\n`);
               fs.writeFileSync(`${outputName}.jsonl`, '');
@@ -268,15 +268,16 @@ jobs:
             let created = 0;
             let skipped = 0;
 
-            for (const d of dirs) {
-              const dir = `${p}/${d}`;
-              if (fs.existsSync(`${dir}/${outputName}.md`)) {
-                md.push(fs.readFileSync(`${dir}/${outputName}.md`, 'utf8'));
+            // Handle both artifact layouts (#125):
+            // - Multiple artifacts: p/plan-xxx-0/plan.md (subdirectories)
+            // - Single artifact (download-artifact v5+): p/plan.md (flat)
+            function collectEntry(mdPath, jsonlPath) {
+              if (fs.existsSync(mdPath)) {
+                md.push(fs.readFileSync(mdPath, 'utf8'));
               }
-              if (fs.existsSync(`${dir}/${outputName}.jsonl`)) {
-                const jsonlContent = fs.readFileSync(`${dir}/${outputName}.jsonl`, 'utf8');
+              if (fs.existsSync(jsonlPath)) {
+                const jsonlContent = fs.readFileSync(jsonlPath, 'utf8');
                 lines.push(jsonlContent);
-                // Parse for stats
                 try {
                   const record = JSON.parse(jsonlContent.trim());
                   if (record.status === 'compliant') compliant++;
@@ -284,6 +285,16 @@ jobs:
                   else if (record.status === 'created') created++;
                   else if (record.status === 'issue_exists') skipped++;
                 } catch (e) {}
+              }
+            }
+
+            for (const entry of entries) {
+              const entryPath = `${p}/${entry}`;
+              const stat = fs.statSync(entryPath);
+              if (stat.isDirectory()) {
+                collectEntry(`${entryPath}/${outputName}.md`, `${entryPath}/${outputName}.jsonl`);
+              } else if (entry === `${outputName}.jsonl`) {
+                collectEntry(`${p}/${outputName}.md`, entryPath);
               }
             }
 

--- a/.github/workflows/campaign-release-info.yml
+++ b/.github/workflows/campaign-release-info.yml
@@ -289,17 +289,27 @@ jobs:
               return;
             }
             const md = []; const lines = [];
-            const dirs = fs.readdirSync(p);
-            if (dirs.length === 0) {
+            const entries = fs.readdirSync(p);
+            if (entries.length === 0) {
               console.log(`${p} directory is empty, no artifacts were downloaded`);
               fs.writeFileSync(`${outputName}.md`, `# No ${outputName} artifacts found\n`);
               fs.writeFileSync(`${outputName}.jsonl`, '');
               return;
             }
-            for (const d of dirs) {
-              const dir = `${p}/${d}`;
-              if (fs.existsSync(`${dir}/${outputName}.md`))    md.push(fs.readFileSync(`${dir}/${outputName}.md`,'utf8'));
-              if (fs.existsSync(`${dir}/${outputName}.jsonl`)) lines.push(fs.readFileSync(`${dir}/${outputName}.jsonl`,'utf8'));
+            // Handle both artifact layouts (#125):
+            // - Multiple artifacts: p/plan-xxx-0/plan.md (subdirectories)
+            // - Single artifact (download-artifact v5+): p/plan.md (flat)
+            for (const entry of entries) {
+              const entryPath = `${p}/${entry}`;
+              const stat = fs.statSync(entryPath);
+              if (stat.isDirectory()) {
+                if (fs.existsSync(`${entryPath}/${outputName}.md`))    md.push(fs.readFileSync(`${entryPath}/${outputName}.md`,'utf8'));
+                if (fs.existsSync(`${entryPath}/${outputName}.jsonl`)) lines.push(fs.readFileSync(`${entryPath}/${outputName}.jsonl`,'utf8'));
+              } else if (entry === `${outputName}.md`) {
+                md.push(fs.readFileSync(entryPath, 'utf8'));
+              } else if (entry === `${outputName}.jsonl`) {
+                lines.push(fs.readFileSync(entryPath, 'utf8'));
+              }
             }
             fs.writeFileSync(`${outputName}.md`, md.join('\n'));
             fs.writeFileSync(`${outputName}.jsonl`, lines.join(''));


### PR DESCRIPTION
Fixes #125

Same fix as #137 applied to the remaining two campaign workflows:
- `campaign-release-info.yml`
- `campaign-api-version-wip-check.yml`

The aggregate merge code now handles both artifact layouts:
- **Multiple artifacts**: subdirectories (download-artifact default for multiple matches)
- **Single artifact**: flat files (download-artifact v5+ behavior for single match)

All three campaign workflows tested on fork with single-repository dry-runs -- correct results.