### PR TITLE
Fix Progress Tracker PR noise from volatile metadata

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_data: ${{ steps.collect.outcome == 'success' }}
+      data_changed: ${{ steps.collect.outputs.data_changed }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v6
@@ -46,6 +47,12 @@ jobs:
           repository: ${{ env.SOURCE_REPO }}
           ref: ${{ env.SOURCE_REF }}
           path: project-admin
+
+      - name: Checkout caller repository (for existing data)
+        uses: actions/checkout@v6
+        with:
+          path: caller-repo
+          sparse-checkout: data/
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -61,9 +68,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          EXISTING_ARG=""
+          if [ -f "${{ github.workspace }}/caller-repo/data/releases-progress.yaml" ]; then
+            EXISTING_ARG="--existing ${{ github.workspace }}/caller-repo/data/releases-progress.yaml"
+          fi
+
           python3 -m scripts.collect_progress \
             --master ../../data/releases-master.yaml \
             --output ${{ runner.temp }}/releases-progress.yaml \
+            $EXISTING_ARG \
             ${{ inputs.debug && '--debug' || '' }}
 
           echo "Collected data:"
@@ -153,7 +166,7 @@ jobs:
   create-data-pr:
     name: Create Data PR
     needs: collect-and-generate
-    if: needs.collect-and-generate.result == 'success'
+    if: needs.collect-and-generate.outputs.data_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -169,25 +182,17 @@ jobs:
           name: progress-data
           path: data
 
-      - name: Check for changes
+      - name: Generate change summary
         id: diff
         run: |
-          # Stage all files so git diff --cached detects both new and modified files
           git add data/
-          if git diff --cached --quiet data/; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected in data/"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "change_summary<<EOF" >> $GITHUB_OUTPUT
-            git diff --cached --stat data/ >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "Changes detected:"
-            git diff --cached --stat data/
-          fi
+          echo "change_summary<<EOF" >> $GITHUB_OUTPUT
+          git diff --cached --stat data/ >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Changes detected:"
+          git diff --cached --stat data/
 
       - name: Create pull request
-        if: steps.diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           branch: release-progress-update-${{ github.run_number }}
@@ -234,8 +239,13 @@ jobs:
           echo "| Create Data PR | ${{ needs.create-data-pr.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
+          # Data changed
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Data changed**: ${{ needs.collect-and-generate.outputs.data_changed }}" >> $GITHUB_STEP_SUMMARY
+
           # Viewer URL
           if [[ "${{ needs.deploy-viewer.result }}" == "success" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Viewer" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Deployed to: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_STEP_SUMMARY

--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -12,45 +12,31 @@ required:
 properties:
   metadata:
     type: object
-    description: Collection metadata and statistics
+    description: Collection metadata and timestamps
     required:
       - last_updated
+      - last_checked
       - schema_version
       - collector_version
-      - collection_stats
     properties:
       last_updated:
         type: string
         format: date-time
-        description: When the data was last collected
+        description: When progress data last changed
+      last_checked:
+        type: string
+        format: date-time
+        description: When data was last collected (every run)
+      releases_master_updated:
+        type: string
+        format: date-time
+        description: When releases-master.yaml was last modified (source data freshness)
       schema_version:
         type: string
         pattern: "^\\d+\\.\\d+\\.\\d+$"
       collector_version:
         type: string
         pattern: "^\\d+\\.\\d+\\.\\d+$"
-      collection_stats:
-        type: object
-        required:
-          - repos_scanned
-          - repos_with_plan
-          - repos_planned
-        properties:
-          repos_scanned:
-            type: integer
-            description: Total repositories checked
-          repos_with_plan:
-            type: integer
-            description: Repositories with release-plan.yaml
-          repos_planned:
-            type: integer
-            description: Repositories with active release plans (type != none)
-          api_calls:
-            type: integer
-            description: Total GitHub API calls made
-          duration_seconds:
-            type: number
-            description: Collection duration in seconds
 
   meta_releases:
     type: array

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -13,9 +13,11 @@ Usage:
 
 import argparse
 import logging
+import os
 import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
@@ -36,8 +38,8 @@ from .warnings import generate_warnings
 
 logger = logging.getLogger(__name__)
 
-COLLECTOR_VERSION = "1.0.0"
-SCHEMA_VERSION = "1.0.0"
+COLLECTOR_VERSION = "1.1.0"
+SCHEMA_VERSION = "1.1.0"
 
 
 def load_releases_master(path: str) -> Dict:
@@ -189,9 +191,34 @@ def collect_repo_progress(
     return entry
 
 
+def compare_progress_data(new_dict: Dict, existing_dict: Dict) -> bool:
+    """Compare stable data sections between new and existing output.
+
+    Only compares ``progress`` and ``meta_releases`` sections.
+    Metadata fields (timestamps, stats) are excluded because they
+    change on every collection run.
+
+    Returns True if data has changed, False if identical.
+    """
+    def normalize_progress(entries):
+        return sorted(entries, key=lambda e: e.get("repository", ""))
+
+    new_progress = normalize_progress(new_dict.get("progress", []))
+    existing_progress = normalize_progress(existing_dict.get("progress", []))
+
+    if new_progress != existing_progress:
+        return True
+
+    new_meta = new_dict.get("meta_releases", [])
+    existing_meta = existing_dict.get("meta_releases", [])
+
+    return new_meta != existing_meta
+
+
 def collect_all(
     master_path: str,
     output_path: str,
+    existing_path: Optional[str] = None,
     api: Optional[GitHubAPI] = None,
 ) -> ProgressData:
     """Main collection loop.
@@ -199,6 +226,9 @@ def collect_all(
     Args:
         master_path: Path to releases-master.yaml.
         output_path: Path to write releases-progress.yaml.
+        existing_path: Path to existing releases-progress.yaml for comparison.
+            When provided, only signals data_changed=True if progress or
+            meta_releases sections differ from the existing file.
         api: GitHubAPI instance (created from env if not provided).
 
     Returns:
@@ -250,8 +280,15 @@ def collect_all(
     stats.api_calls = api.api_calls
     stats.duration_seconds = time.time() - start_time
 
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Read source data freshness from releases-master.yaml metadata
+    master_metadata = master.get("metadata", {})
+    releases_master_updated = master_metadata.get("last_updated", "")
+
     progress_data = ProgressData(
-        last_updated=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        last_checked=now,
+        releases_master_updated=releases_master_updated,
         schema_version=SCHEMA_VERSION,
         collector_version=COLLECTOR_VERSION,
         collection_stats=stats,
@@ -259,16 +296,43 @@ def collect_all(
         progress=entries,
     )
 
-    # Write output
+    # Compare with existing file to determine if data actually changed
+    new_output = progress_data.to_dict()
+    data_changed = True
+
+    if existing_path:
+        existing_file = Path(existing_path)
+        if existing_file.exists():
+            try:
+                with open(existing_file, "r") as f:
+                    existing_data = yaml.safe_load(f) or {}
+                data_changed = compare_progress_data(new_output, existing_data)
+                if not data_changed:
+                    # Carry forward last_updated from existing file
+                    existing_last_updated = existing_data.get("metadata", {}).get(
+                        "last_updated", now
+                    )
+                    progress_data.last_updated = existing_last_updated
+                    logger.info("No data changes detected, carrying forward last_updated")
+            except Exception as e:
+                logger.warning("Failed to read existing file: %s, treating as changed", e)
+                data_changed = True
+
+    if data_changed:
+        progress_data.last_updated = now
+
+    progress_data.data_changed = data_changed
+
+    # Write output (always write — last_checked changes every run for the viewer)
     output = progress_data.to_dict()
     with open(output_path, "w") as f:
         yaml.dump(output, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
     logger.info(
         "Collection complete: %d repos scanned, %d with plan, %d planned, "
-        "%d API calls in %.1fs",
+        "%d API calls in %.1fs, data_changed=%s",
         stats.repos_scanned, stats.repos_with_plan, stats.repos_planned,
-        stats.api_calls, stats.duration_seconds,
+        stats.api_calls, stats.duration_seconds, data_changed,
     )
 
     return progress_data
@@ -288,6 +352,10 @@ def main():
         help="Path to write releases-progress.yaml",
     )
     parser.add_argument(
+        "--existing", required=False, default=None,
+        help="Path to existing releases-progress.yaml for change comparison",
+    )
+    parser.add_argument(
         "--debug", action="store_true",
         help="Enable debug logging",
     )
@@ -299,7 +367,25 @@ def main():
     )
 
     try:
-        collect_all(args.master, args.output)
+        result = collect_all(args.master, args.output, existing_path=args.existing)
+
+        # Output data_changed for workflow consumption
+        github_output = os.environ.get("GITHUB_OUTPUT")
+        if github_output:
+            with open(github_output, "a") as f:
+                f.write(f"data_changed={'true' if result.data_changed else 'false'}\n")
+
+        # Log collection stats for workflow summary
+        stats = result.collection_stats
+        print(f"::group::Collection Statistics")
+        print(f"Repos scanned: {stats.repos_scanned}")
+        print(f"Repos with plan: {stats.repos_with_plan}")
+        print(f"Repos planned: {stats.repos_planned}")
+        print(f"API calls: {stats.api_calls}")
+        print(f"Duration: {stats.duration_seconds:.1f}s")
+        print(f"Data changed: {result.data_changed}")
+        print(f"::endgroup::")
+
     except Exception as e:
         logger.error("Collection failed: %s", e)
         sys.exit(1)

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -206,10 +206,13 @@ class CollectionStats:
 @dataclass
 class ProgressData:
     """Top-level output structure for releases-progress.yaml."""
-    last_updated: str = ""
-    schema_version: str = "1.0.0"
-    collector_version: str = "1.0.0"
-    collection_stats: CollectionStats = field(default_factory=CollectionStats)
+    last_updated: str = ""            # When progress data last changed
+    last_checked: str = ""            # When data was last collected (every run)
+    releases_master_updated: str = "" # When releases-master.yaml was last modified
+    schema_version: str = "1.1.0"
+    collector_version: str = "1.1.0"
+    collection_stats: CollectionStats = field(default_factory=CollectionStats)  # Internal only
+    data_changed: bool = True         # Internal flag, not serialized
     meta_releases: List[MetaReleaseSummary] = field(default_factory=list)
     progress: List[ProgressEntry] = field(default_factory=list)
 
@@ -217,9 +220,10 @@ class ProgressData:
         return {
             "metadata": {
                 "last_updated": self.last_updated,
+                "last_checked": self.last_checked,
+                "releases_master_updated": self.releases_master_updated,
                 "schema_version": self.schema_version,
                 "collector_version": self.collector_version,
-                "collection_stats": self.collection_stats.to_dict(),
             },
             "meta_releases": [m.to_dict() for m in self.meta_releases],
             "progress": [e.to_dict() for e in self.progress],

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -990,16 +990,23 @@ tr.not-planned-row:hover td {
      */
     function renderFooter(data) {
       const footerDiv = document.getElementById('footer-metadata');
-      const updated = new Date(data.metadata.last_updated).toLocaleString('en-US', {
-        year: 'numeric', month: 'short', day: 'numeric',
-        hour: '2-digit', minute: '2-digit'
-      });
-      const stats = data.metadata.collection_stats;
-      footerDiv.innerHTML = `
-        Data collected: ${updated} |
-        ${stats.repos_scanned} repos scanned |
-        Schema v${data.metadata.schema_version}
-      `;
+      const fmt = (iso) => {
+        if (!iso) return '\u2014';
+        return new Date(iso).toLocaleString('en-US', {
+          year: 'numeric', month: 'short', day: 'numeric',
+          hour: '2-digit', minute: '2-digit'
+        });
+      };
+      const meta = data.metadata;
+      const parts = [
+        `Last checked: ${fmt(meta.last_checked || meta.last_updated)}`,
+        `Data updated: ${fmt(meta.last_updated)}`,
+      ];
+      if (meta.releases_master_updated) {
+        parts.push(`Source data: ${fmt(meta.releases_master_updated)}`);
+      }
+      parts.push(`Schema v${meta.schema_version}`);
+      footerDiv.innerHTML = parts.join(' | ');
     }
 
     // ===== Initialization =====

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -10,6 +10,7 @@ from scripts.collect_progress import (
     build_published_context_map,
     collect_all,
     collect_repo_progress,
+    compare_progress_data,
     load_releases_master,
     parse_release_plan,
 )
@@ -262,6 +263,80 @@ class TestCollectRepoProgress:
         assert any(w.code == "W002" for w in result.warnings)
 
 
+class TestCompareProgressData:
+    """Tests for the two-phase comparison logic."""
+
+    SAMPLE_OUTPUT = {
+        "metadata": {
+            "last_updated": "2026-03-01T00:00:00Z",
+            "last_checked": "2026-03-01T00:00:00Z",
+            "releases_master_updated": "2026-03-01T00:00:00Z",
+            "schema_version": "1.1.0",
+            "collector_version": "1.1.0",
+        },
+        "meta_releases": [
+            {"name": "Sync26", "total_apis": 5, "m1_achieved": 2,
+             "m3_achieved": 1, "m4_achieved": 0},
+        ],
+        "progress": [
+            {"repository": "QualityOnDemand", "state": "planned",
+             "github_url": "https://example.com/QoD"},
+            {"repository": "InactiveRepo", "state": "not_planned",
+             "github_url": "https://example.com/Inactive"},
+        ],
+    }
+
+    def test_identical_data_returns_false(self):
+        """Same progress + meta_releases → no change."""
+        import copy
+        existing = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        # Metadata differs (timestamps) but stable data is the same
+        new["metadata"]["last_checked"] = "2026-03-02T00:00:00Z"
+        assert compare_progress_data(new, existing) is False
+
+    def test_different_progress_returns_true(self):
+        """Changed state → change detected."""
+        import copy
+        existing = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new["progress"][0]["state"] = "snapshot_active"
+        assert compare_progress_data(new, existing) is True
+
+    def test_different_meta_releases_returns_true(self):
+        """Changed counts → change detected."""
+        import copy
+        existing = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new["meta_releases"][0]["m1_achieved"] = 3
+        assert compare_progress_data(new, existing) is True
+
+    def test_different_order_same_data_returns_false(self):
+        """Repos in different order → no change (normalization)."""
+        import copy
+        existing = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new["progress"] = list(reversed(new["progress"]))
+        assert compare_progress_data(new, existing) is False
+
+    def test_empty_existing_returns_true(self):
+        """No existing data → always changed."""
+        import copy
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        assert compare_progress_data(new, {}) is True
+
+    def test_new_repo_added_returns_true(self):
+        """New repo in progress → change detected."""
+        import copy
+        existing = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new = copy.deepcopy(self.SAMPLE_OUTPUT)
+        new["progress"].append(
+            {"repository": "NewRepo", "state": "planned",
+             "github_url": "https://example.com/New"},
+        )
+        assert compare_progress_data(new, existing) is True
+
+
 class TestCollectAll:
     def test_full_collection(self, tmp_path):
         """End-to-end test with mock API."""
@@ -282,12 +357,20 @@ class TestCollectAll:
         assert result.collection_stats.repos_with_plan == 2
         assert result.collection_stats.repos_planned == 1  # Only QoD is active
 
-        # Verify output file written
+        # Verify output file written with new schema
         assert output_file.exists()
         output = yaml.safe_load(output_file.read_text())
         assert "metadata" in output
         assert "progress" in output
         assert len(output["progress"]) == 2
+
+        # Verify new metadata fields
+        meta = output["metadata"]
+        assert "last_updated" in meta
+        assert "last_checked" in meta
+        assert "releases_master_updated" in meta
+        assert meta["schema_version"] == "1.1.0"
+        assert "collection_stats" not in meta  # Removed from output
 
     def test_collection_handles_api_errors(self, tmp_path):
         """Repos with API errors should be skipped gracefully."""
@@ -313,3 +396,113 @@ class TestCollectAll:
         assert result.collection_stats.repos_scanned == 1
         assert result.collection_stats.repos_with_plan == 0
         assert len(result.progress) == 0
+
+    def test_releases_master_updated_populated(self, tmp_path):
+        """releases_master_updated should be read from master file metadata."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(SAMPLE_MASTER))
+
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+        )
+        result = collect_all(str(master_file), str(output_file), api=api)
+
+        assert result.releases_master_updated == "2026-03-01T00:00:00Z"
+        output = yaml.safe_load(output_file.read_text())
+        assert output["metadata"]["releases_master_updated"] == "2026-03-01T00:00:00Z"
+
+
+class TestCollectAllWithExisting:
+    """Tests for the two-phase write with existing file comparison."""
+
+    def _make_api(self):
+        return MockGitHubAPI(
+            file_contents={
+                "QualityOnDemand/release-plan.yaml": PLAN_RC,
+                "InactiveRepo/release-plan.yaml": PLAN_NONE,
+            },
+        )
+
+    def test_no_existing_file_treated_as_changed(self, tmp_path):
+        """Missing existing file → data_changed = True."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(SAMPLE_MASTER))
+
+        result = collect_all(
+            str(master_file), str(output_file),
+            existing_path=str(tmp_path / "nonexistent.yaml"),
+            api=self._make_api(),
+        )
+        assert result.data_changed is True
+
+    def test_unchanged_carries_forward_last_updated(self, tmp_path):
+        """Same data → last_updated preserved from existing, data_changed = False."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        existing_file = tmp_path / "existing.yaml"
+        master_file.write_text(yaml.dump(SAMPLE_MASTER))
+
+        # First run: generate baseline
+        api1 = self._make_api()
+        collect_all(str(master_file), str(output_file), api=api1)
+
+        # Copy output as existing file
+        existing_file.write_text(output_file.read_text())
+        original_output = yaml.safe_load(existing_file.read_text())
+        original_last_updated = original_output["metadata"]["last_updated"]
+
+        # Second run: same data, with existing
+        api2 = self._make_api()
+        result = collect_all(
+            str(master_file), str(output_file),
+            existing_path=str(existing_file),
+            api=api2,
+        )
+
+        assert result.data_changed is False
+        assert result.last_updated == original_last_updated
+        # last_checked should be current (newer than last_updated)
+        assert result.last_checked >= original_last_updated
+
+    def test_changed_data_updates_last_updated(self, tmp_path):
+        """Different data → last_updated = last_checked, data_changed = True."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        existing_file = tmp_path / "existing.yaml"
+        master_file.write_text(yaml.dump(SAMPLE_MASTER))
+
+        # First run: generate baseline
+        api1 = self._make_api()
+        collect_all(str(master_file), str(output_file), api=api1)
+        existing_file.write_text(output_file.read_text())
+
+        # Second run: different data (add snapshot branch → state change)
+        api2 = MockGitHubAPI(
+            file_contents={
+                "QualityOnDemand/release-plan.yaml": PLAN_RC,
+                "InactiveRepo/release-plan.yaml": PLAN_NONE,
+            },
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123"]},
+        )
+        result = collect_all(
+            str(master_file), str(output_file),
+            existing_path=str(existing_file),
+            api=api2,
+        )
+
+        assert result.data_changed is True
+        assert result.last_updated == result.last_checked
+
+    def test_no_existing_path_always_changed(self, tmp_path):
+        """No existing_path argument → data_changed = True (default)."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(SAMPLE_MASTER))
+
+        result = collect_all(
+            str(master_file), str(output_file),
+            api=self._make_api(),
+        )
+        assert result.data_changed is True

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -119,6 +119,8 @@ class TestProgressData:
     def test_full_output_structure(self):
         data = ProgressData(
             last_updated="2026-03-15T10:00:00Z",
+            last_checked="2026-03-15T10:00:00Z",
+            releases_master_updated="2026-03-15T04:35:00Z",
             collection_stats=CollectionStats(
                 repos_scanned=63, repos_with_plan=45,
                 repos_planned=38, api_calls=200, duration_seconds=95.3,
@@ -137,8 +139,10 @@ class TestProgressData:
         )
         d = data.to_dict()
 
-        assert d["metadata"]["schema_version"] == "1.0.0"
-        assert d["metadata"]["collection_stats"]["repos_scanned"] == 63
+        assert d["metadata"]["schema_version"] == "1.1.0"
+        assert d["metadata"]["last_checked"] == "2026-03-15T10:00:00Z"
+        assert d["metadata"]["releases_master_updated"] == "2026-03-15T04:35:00Z"
+        assert "collection_stats" not in d["metadata"]  # Removed from output
         assert len(d["meta_releases"]) == 1
         assert d["meta_releases"][0]["name"] == "Sync26"
         assert len(d["progress"]) == 1
@@ -146,4 +150,4 @@ class TestProgressData:
         # Full YAML round-trip
         yaml_str = yaml.dump(d, default_flow_style=False, sort_keys=False)
         reloaded = yaml.safe_load(yaml_str)
-        assert reloaded["metadata"]["collector_version"] == "1.0.0"
+        assert reloaded["metadata"]["collector_version"] == "1.1.0"


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

The Release Progress Tracker creates a data PR on every scheduled run (2x daily) even when no release progress has actually changed. Root cause: three volatile metadata fields (`last_updated`, `collection_stats.api_calls`, `collection_stats.duration_seconds`) change on every collection run, defeating the `git diff --cached --quiet` change gate in the workflow.

This PR implements a two-phase write approach:
- The collector compares only stable data sections (`progress`, `meta_releases`) against the existing committed file
- PRs are gated on the `data_changed` output from the collector instead of `git diff`
- Volatile collection stats are logged to the workflow summary instead of the committed file

Schema changes (1.0.0 → 1.1.0):
- Add `last_checked` (every run) and `releases_master_updated` (source data freshness) timestamps
- Remove `collection_stats` from committed output
- Viewer footer updated to display all three timestamps

#### Which issue(s) this PR fixes:

Fixes https://github.com/camaraproject/ReleaseManagement/issues/405

#### Special notes for reviewers:

The `--existing` CLI argument is optional for backwards compatibility. When omitted, the collector behaves as before (always signals data changed). The workflow passes the existing committed file via a separate caller-repo checkout.

69 tests pass (13 new tests for comparison logic and carry-forward behavior).

#### Changelog input

```
release-note
Fix Progress Tracker creating unnecessary data PRs on every run
```

#### Additional documentation

```
docs
N/A
```