### PR TITLE
fix(progress-viewer): hide empty pills in iframe + consolidate version constants

### DIFF
--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -25,6 +25,8 @@ import yaml
 from .github_api import GitHubAPI, RateLimitError
 from .milestone_deriver import build_meta_release_summaries, derive_cycle_releases
 from .models import (
+    COLLECTOR_VERSION,
+    SCHEMA_VERSION,
     ApiEntry,
     ArtifactInfo,
     CollectionStats,
@@ -37,9 +39,6 @@ from .state_deriver import derive_state, find_matching_snapshot
 from .warnings import generate_warnings
 
 logger = logging.getLogger(__name__)
-
-COLLECTOR_VERSION = "1.2.0"
-SCHEMA_VERSION = "1.2.0"
 
 
 def load_releases_master(path: str) -> Dict:

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 
+# Single source of truth for version constants — update here only
+SCHEMA_VERSION = "1.2.0"
+COLLECTOR_VERSION = "1.2.0"
+
 
 class ProgressState(Enum):
     """Release progress state derived from repository artifacts."""
@@ -209,8 +213,8 @@ class ProgressData:
     last_updated: str = ""            # When progress data last changed
     last_checked: str = ""            # When data was last collected (every run)
     releases_master_updated: str = "" # When releases-master.yaml was last modified
-    schema_version: str = "1.2.0"
-    collector_version: str = "1.2.0"
+    schema_version: str = SCHEMA_VERSION
+    collector_version: str = COLLECTOR_VERSION
     collection_stats: CollectionStats = field(default_factory=CollectionStats)  # Internal only
     data_changed: bool = True         # Internal flag, not serialized
     meta_releases: List[MetaReleaseSummary] = field(default_factory=list)

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -1005,6 +1005,8 @@ tr.not-planned-row:hover td {
       const inIframe = ViewerLib.isInIframe();
       if (!inIframe || !currentTrackFilter) {
         buildTrackPills();
+      } else {
+        document.getElementById('trackPills').style.display = 'none';
       }
 
       applyFilters();           // calls updateHeader(), renderTable(), updateTrackPillStates()


### PR DESCRIPTION
#### What type of PR is this?

* bug
* cleanup

#### What this PR does / why we need it:

1. Hides the empty track pills container when the Progress Viewer is embedded in an iframe with a `track` query parameter. Previously, the pills rendering was correctly skipped but the empty `<div>` container remained visible as a blank box.

2. Consolidates `SCHEMA_VERSION` and `COLLECTOR_VERSION` constants into `models.py` as single source of truth. Previously these were duplicated in both `collect_progress.py` and `models.py`, requiring lockstep updates (caught during Session 086 testing).

#### Which issue(s) this PR fixes:

N/A (internal improvement)

#### Special notes for reviewers:

69 existing tests pass without changes. The version constant consolidation is a no-op at runtime — `collect_progress.py` now imports the same values from `models.py` instead of defining its own copies.

#### Changelog input

```
 release-note
N/A
```

#### Additional documentation

```
docs
N/A
```