### PR TITLE
fix(release-collector): change default execution_mode to pr

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -42,7 +42,7 @@ on:
         options:
           - dry-run       # Test mode - no commits, artifacts only
           - pr            # Create pull request for review
-        default: dry-run
+        default: pr
 
       debug_mode:
         description: 'Enable debug logging'


### PR DESCRIPTION
#### What type of PR is this?

* correction


#### What this PR does / why we need it:

Changes the `workflow_dispatch` default for `execution_mode` from `dry-run` to `pr`. Manual dispatch runs were silently skipping PR creation and staging deployment because `dry-run` was pre-selected.

The schedule fallback already defaults to `pr` (line 73), so this aligns the two entry points.


#### Which issue(s) this PR fixes:

Related to #161 (broader Release Collector adaptation for automation-created releases).


#### Special notes for reviewers:

One-line change. No functional impact on scheduled runs (already defaulted to `pr`).


#### Changelog input

```
fix: Release Collector workflow_dispatch now defaults to pr mode instead of dry-run
```

#### Additional documentation 

n/a