### PR TITLE
chore: update onboarding workflow default ref to ra-v1-rc

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -42,7 +42,7 @@ on:
         description: 'Ref for the caller workflow uses: line (branch or tag in camaraproject/tooling)'
         required: false
         type: string
-        default: 'release-automation'
+        default: 'ra-v1-rc'
 
 concurrency:
   group: campaign-release-automation-onboarding-${{ github.ref }}


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Updates the `caller_ref` default in the onboarding campaign workflow from `release-automation` to `ra-v1-rc`. New onboarding runs will reference the release candidate tag by default.

#### Which issue(s) this PR fixes:

Part of release automation RC milestone preparation.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Aligns onboarding with the `ra-v1-rc` milestone tag on `camaraproject/tooling`.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation 

```
docs
N/A
```