### PR TITLE
Fix App bot identity resolution in onboarding campaign

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -156,6 +156,23 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
+      - name: Resolve Bot Identity
+        id: bot-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -n "${{ vars.RELEASE_APP_SLUG }}" ] && [ -n "${{ steps.app-token.outputs.token }}" ]; then
+            BOT_LOGIN="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          else
+            BOT_LOGIN="github-actions[bot]"
+          fi
+          BOT_INFO=$(gh api "/users/$BOT_LOGIN" --jq '{id: .id, login: .login}')
+          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
+          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
+          echo "Committing as: $BOT_NAME <${BOT_ID}+${BOT_NAME}@users.noreply.github.com>"
+          echo "bot_name=$BOT_NAME" >> $GITHUB_OUTPUT
+          echo "bot_email=${BOT_ID}+${BOT_NAME}@users.noreply.github.com" >> $GITHUB_OUTPUT
+
       - name: Checkout admin repo (self)
         uses: actions/checkout@v6
         with:
@@ -368,6 +385,8 @@ jobs:
           pr_body_file: /tmp/pr-body.md
           branch: ${{ env.BRANCH }}
           github_token: ${{ steps.app-token.outputs.token }}
+          bot_name: ${{ steps.bot-identity.outputs.bot_name }}
+          bot_email: ${{ steps.bot-identity.outputs.bot_email }}
           target_files: .github/workflows/release-automation.yml CHANGELOG.md CHANGELOG/README.md
           error_occurred: ${{ steps.fetch_caller.outputs.error || 'false' }}
           error_message: "Failed to fetch caller workflow template"

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -39,6 +39,14 @@ inputs:
     description: 'GitHub token for PR creation (apply mode only)'
     required: false
     default: ''
+  bot_name:
+    description: 'Git commit author name (optional, overrides gh api user auto-detection)'
+    required: false
+    default: ''
+  bot_email:
+    description: 'Git commit author email (optional, overrides gh api user auto-detection)'
+    required: false
+    default: ''
   error_occurred:
     description: 'Whether an error occurred during workflow execution'
     required: false
@@ -213,19 +221,24 @@ runs:
       shell: bash
       working-directory: repo
       run: |
-        # Derive git user from token identity
-        if ! TOKEN_INFO=$(gh api user --jq '{login: .login, id: .id}' 2>&1); then
-          echo "::error::Failed to get token identity: $TOKEN_INFO"
-          exit 1
+        # Derive git user from explicit inputs or token identity
+        if [ -n "${{ inputs.bot_name }}" ] && [ -n "${{ inputs.bot_email }}" ]; then
+          GIT_USER_NAME="${{ inputs.bot_name }}"
+          GIT_USER_EMAIL="${{ inputs.bot_email }}"
+        else
+          if ! TOKEN_INFO=$(gh api user --jq '{login: .login, id: .id}' 2>&1); then
+            echo "::error::Failed to get token identity: $TOKEN_INFO"
+            exit 1
+          fi
+          TOKEN_USER=$(echo "$TOKEN_INFO" | jq -r '.login')
+          TOKEN_ID=$(echo "$TOKEN_INFO" | jq -r '.id')
+          if [ -z "$TOKEN_USER" ] || [ "$TOKEN_USER" = "null" ]; then
+            echo "::error::Could not determine token user identity"
+            exit 1
+          fi
+          GIT_USER_NAME="${TOKEN_USER}"
+          GIT_USER_EMAIL="${TOKEN_ID}+${TOKEN_USER}@users.noreply.github.com"
         fi
-        TOKEN_USER=$(echo "$TOKEN_INFO" | jq -r '.login')
-        TOKEN_ID=$(echo "$TOKEN_INFO" | jq -r '.id')
-        if [ -z "$TOKEN_USER" ] || [ "$TOKEN_USER" = "null" ]; then
-          echo "::error::Could not determine token user identity"
-          exit 1
-        fi
-        GIT_USER_NAME="${TOKEN_USER}"
-        GIT_USER_EMAIL="${TOKEN_ID}+${TOKEN_USER}@users.noreply.github.com"
         echo "Committing as: $GIT_USER_NAME <$GIT_USER_EMAIL>"
         git config user.name "$GIT_USER_NAME"
         git config user.email "$GIT_USER_EMAIL"


### PR DESCRIPTION
#### What type of PR is this?

* bug


#### What this PR does / why we need it:

Fixes the bot identity resolution for campaign commits when using the GitHub App token (introduced in PA#167). App installation tokens cannot access the `/user` API endpoint (403). This PR adds explicit bot identity resolution via `/users/{slug}[bot]` using `vars.RELEASE_APP_SLUG`, matching the pattern in `release-automation-reusable.yml`.

Changes:
- **Workflow**: adds "Resolve Bot Identity" step that looks up the bot user via `/users/{slug}[bot]`, passes `bot_name`/`bot_email` to the composite action
- **`campaign-finalize-per-repo` action**: adds optional `bot_name`/`bot_email` inputs that override the `gh api user` auto-detection, maintaining backward compatibility for PAT-based callers

#### Which issue(s) this PR fixes:

Fixes regression from PA#167

#### Special notes for reviewers:

Tested with plan mode (run 22727104366, success) and apply mode (run 22727218698, failed on `gh api user` 403 — this PR fixes that).

#### Changelog input

```
 release-note
N/A
```

#### Additional documentation 

This section can be blank.

```
docs
N/A
```