### PR TITLE
fix: use org-scoped App token for all campaign workflows

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -155,23 +155,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
-      - name: Resolve Bot Identity
-        id: bot-identity
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          if [ -n "${{ vars.RELEASE_APP_SLUG }}" ] && [ -n "${{ steps.app-token.outputs.token }}" ]; then
-            BOT_LOGIN="${{ vars.RELEASE_APP_SLUG }}[bot]"
-          else
-            BOT_LOGIN="github-actions[bot]"
-          fi
-          BOT_INFO=$(gh api "/users/$BOT_LOGIN" --jq '{id: .id, login: .login}')
-          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
-          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
-          echo "Committing as: $BOT_NAME <${BOT_ID}+${BOT_NAME}@users.noreply.github.com>"
-          echo "bot_name=$BOT_NAME" >> $GITHUB_OUTPUT
-          echo "bot_email=${BOT_ID}+${BOT_NAME}@users.noreply.github.com" >> $GITHUB_OUTPUT
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout admin repo (self)
         uses: actions/checkout@v6
@@ -304,6 +288,16 @@ jobs:
             git diff --cached --name-only
           fi
 
+      - name: Configure git identity
+        if: ${{ env.MODE == 'apply' }}
+        run: |
+          BOT="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          BOT_ID=$(gh api /users/$BOT --jq '.id')
+          git -C repo config user.name "$BOT"
+          git -C repo config user.email "${BOT_ID}+${BOT}@users.noreply.github.com"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Build campaign data JSON
         id: campaign_data
         shell: bash
@@ -385,8 +379,6 @@ jobs:
           pr_body_file: /tmp/pr-body.md
           branch: ${{ env.BRANCH }}
           github_token: ${{ steps.app-token.outputs.token }}
-          bot_name: ${{ steps.bot-identity.outputs.bot_name }}
-          bot_email: ${{ steps.bot-identity.outputs.bot_email }}
           target_files: .github/workflows/release-automation.yml CHANGELOG.md CHANGELOG/README.md
           error_occurred: ${{ steps.fetch_caller.outputs.error || 'false' }}
           error_message: "Failed to fetch caller workflow template"

--- a/.github/workflows/campaign-release-info.yml
+++ b/.github/workflows/campaign-release-info.yml
@@ -4,10 +4,9 @@
 # Synchronizes Release Information sections in API repository READMEs based on data
 # from releases-master.yaml. Creates PRs to update release tables across repositories.
 #
-# PREREQUISITES:
-# - Secret BULK_CAMPAIGN_TOKEN: Fine-grained PAT with the following permissions:
-#   - Contents: Read and write (create branches, commit changes)
-#   - Pull requests: Read and write (create PRs in target repos)
+# AUTHENTICATION:
+# - run job: uses camara-release-automation GitHub App token via create-github-app-token action
+#   Requires org-level variable RELEASE_APP_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
 #
 # CHANGELOG:
 # - 2024-12-17: Standardized header format
@@ -150,6 +149,14 @@ jobs:
         repo: ${{ fromJson(needs.select.outputs.repos) }}
 
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout admin repo (self)
         uses: actions/checkout@v6
         with:
@@ -161,7 +168,7 @@ jobs:
           repository: ${{ matrix.repo }}
           path: repo
           fetch-depth: 0
-          token: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Read release data
         id: data
@@ -325,6 +332,16 @@ jobs:
               core.setOutput('error_step', '');
             }
 
+      - name: Configure git identity
+        if: ${{ env.MODE == 'apply' }}
+        run: |
+          BOT="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          BOT_ID=$(gh api /users/$BOT --jq '.id')
+          git -C repo config user.name "$BOT"
+          git -C repo config user.email "${BOT_ID}+${BOT}@users.noreply.github.com"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Finalize campaign per repo
         if: always()
         uses: ./admin/actions/campaign-finalize-per-repo
@@ -336,7 +353,7 @@ jobs:
           pr_base_title: ${{ env.PR_TITLE }}
           pr_body_file: /tmp/pr-body.md
           branch: ${{ env.BRANCH }}
-          github_token: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           error_occurred: ${{ steps.error.outputs.error_occurred }}
           error_message: ${{ steps.error.outputs.error_message }}
           error_step: ${{ steps.error.outputs.error_step }}

--- a/.github/workflows/campaign-release-plan-rollout.yml
+++ b/.github/workflows/campaign-release-plan-rollout.yml
@@ -4,10 +4,10 @@
 # Adds release-plan.yaml to all CAMARA API repositories based on data from
 # releases-master.yaml. Creates PRs for repositories that don't yet have the file.
 #
-# PREREQUISITES:
-# - Secret BULK_CAMPAIGN_TOKEN: Fine-grained PAT with the following permissions:
-#   - Contents: Read and write (create branches, commit changes)
-#   - Pull requests: Read and write (create PRs in target repos)
+# AUTHENTICATION:
+# - select job: uses GITHUB_TOKEN (read-only, public repos)
+# - run job: uses camara-release-automation GitHub App token via create-github-app-token action
+#   Requires org-level variable RELEASE_APP_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
 #
 # DOCUMENTATION:
 # https://github.com/camaraproject/project-administration/blob/main/campaigns/release-plan-rollout/docs/README.md
@@ -81,7 +81,7 @@ jobs:
         name: Build repo list (from repositories array + include filter + skip existing)
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         with:
           script: |
             const fs = require('fs');
@@ -217,6 +217,14 @@ jobs:
         repo: ${{ fromJson(needs.select.outputs.repos) }}
 
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout admin repo (self)
         uses: actions/checkout@v6
         with:
@@ -228,7 +236,7 @@ jobs:
           repository: ${{ matrix.repo }}
           path: repo
           fetch-depth: 0
-          token: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch CODEOWNERS
         id: codeowners
@@ -247,7 +255,7 @@ jobs:
             echo "No CODEOWNERS file found"
           fi
         env:
-          GH_TOKEN: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Generate release-plan.yaml
         id: generate
@@ -305,6 +313,16 @@ jobs:
             echo "::warning::release-plan.yaml was not generated"
           fi
 
+      - name: Configure git identity
+        if: ${{ env.MODE == 'apply' }}
+        run: |
+          BOT="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          BOT_ID=$(gh api /users/$BOT --jq '.id')
+          git -C repo config user.name "$BOT"
+          git -C repo config user.email "${BOT_ID}+${BOT}@users.noreply.github.com"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Campaign finalize
         uses: ./admin/actions/campaign-finalize-per-repo
         with:
@@ -315,7 +333,7 @@ jobs:
           pr_base_title: ${{ env.PR_TITLE }}
           pr_body_file: /tmp/pr-body.md
           branch: ${{ env.BRANCH }}
-          github_token: ${{ secrets.BULK_CAMPAIGN_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           target_files: release-plan.yaml
           error_occurred: ${{ steps.validate.outputs.valid != 'true' }}
           error_message: "Validation failed: ${{ steps.validate.outputs.errors }}"

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -39,14 +39,6 @@ inputs:
     description: 'GitHub token for PR creation (apply mode only)'
     required: false
     default: ''
-  bot_name:
-    description: 'Git commit author name (optional, overrides gh api user auto-detection)'
-    required: false
-    default: ''
-  bot_email:
-    description: 'Git commit author email (optional, overrides gh api user auto-detection)'
-    required: false
-    default: ''
   error_occurred:
     description: 'Whether an error occurred during workflow execution'
     required: false
@@ -221,27 +213,7 @@ runs:
       shell: bash
       working-directory: repo
       run: |
-        # Derive git user from explicit inputs or token identity
-        if [ -n "${{ inputs.bot_name }}" ] && [ -n "${{ inputs.bot_email }}" ]; then
-          GIT_USER_NAME="${{ inputs.bot_name }}"
-          GIT_USER_EMAIL="${{ inputs.bot_email }}"
-        else
-          if ! TOKEN_INFO=$(gh api user --jq '{login: .login, id: .id}' 2>&1); then
-            echo "::error::Failed to get token identity: $TOKEN_INFO"
-            exit 1
-          fi
-          TOKEN_USER=$(echo "$TOKEN_INFO" | jq -r '.login')
-          TOKEN_ID=$(echo "$TOKEN_INFO" | jq -r '.id')
-          if [ -z "$TOKEN_USER" ] || [ "$TOKEN_USER" = "null" ]; then
-            echo "::error::Could not determine token user identity"
-            exit 1
-          fi
-          GIT_USER_NAME="${TOKEN_USER}"
-          GIT_USER_EMAIL="${TOKEN_ID}+${TOKEN_USER}@users.noreply.github.com"
-        fi
-        echo "Committing as: $GIT_USER_NAME <$GIT_USER_EMAIL>"
-        git config user.name "$GIT_USER_NAME"
-        git config user.email "$GIT_USER_EMAIL"
+        # Git identity must be pre-configured by the calling workflow
         git checkout -B "${{ inputs.branch }}"
         for f in ${{ inputs.target_files }}; do
           if [ -e "$f" ]; then


### PR DESCRIPTION
#### What type of PR is this?

* bug
* cleanup

#### What this PR does / why we need it:

Fixes campaign workflow failures caused by `create-github-app-token` generating a token scoped only to project-administration instead of all org repos. Also migrates all three release-automation-related campaigns from `BULK_CAMPAIGN_TOKEN` PAT to GitHub App token, and simplifies the bot identity resolution.

**Changes:**
- Add `owner` parameter to `create-github-app-token` in onboarding campaign (the actual bug fix)
- Migrate release-info and release-plan-rollout campaigns from PAT to App token
- Replace 16-line "Resolve Bot Identity" step with direct git config in each workflow
- Remove `bot_name`/`bot_email` inputs and `gh api user` fallback from `campaign-finalize-per-repo` composite action

#### Which issue(s) this PR fixes:

Fixes https://github.com/camaraproject/project-administration/actions/runs/22728569177

#### Special notes for reviewers:

The `campaign-api-version-wip-check` workflow still uses `BULK_CAMPAIGN_TOKEN` — it's not related to release automation and can be migrated separately if desired.

#### Changelog input

```
 release-note
fix: campaign workflows now use org-scoped GitHub App token instead of PAT
```

#### Additional documentation 

```
docs
n/a
```