### PR TITLE
fix: restore SOURCE_REPO/REF to upstream defaults

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -27,8 +27,8 @@ on:
 env:
   # Source repository and ref for progress tracker code and shared assets.
   # Change these when testing on a fork or switching between branches.
-  SOURCE_REPO: hdamker/project-administration
-  SOURCE_REF: w005-onboarding-warning
+  SOURCE_REPO: camaraproject/project-administration
+  SOURCE_REF: main
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Restores `SOURCE_REPO` and `SOURCE_REF` in the Progress Tracker caller workflow to their upstream defaults (`camaraproject/project-administration` / `main`). A test commit that pointed these to a fork branch was accidentally included in the PA#171 merge.

#### Which issue(s) this PR fixes:

N/A (regression from PA#171)

#### Special notes for reviewers:

One-line fix. The failed run: https://github.com/camaraproject/ReleaseManagement/actions/runs/22758932357

#### Changelog input

```
release-note
N/A
```

#### Additional documentation

```
docs
N/A
```