### PR TITLE
chore(deps): bump composite actions to upload-artifact@v7 and extend Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,26 @@ updates:
           - "*"
         exclude-patterns:
           - "actions/*"
+
+  # Composite actions in actions/ subdirectories
+  - package-ecosystem: "github-actions"
+    directory: "/actions/campaign-finalize-per-repo"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "github-actions"
+    directory: "/actions/campaign-finalize-issue-per-repo"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/actions/campaign-finalize-issue-per-repo/action.yml
+++ b/actions/campaign-finalize-issue-per-repo/action.yml
@@ -157,7 +157,7 @@ runs:
         fi
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.mode == 'plan' && format('plan-{0}-{1}', github.run_id, strategy.job-index) || format('results-{0}-{1}', github.run_id, strategy.job-index) }}
         path: |

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -285,7 +285,7 @@ runs:
         git clean -fd
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.mode == 'plan' && format('plan-{0}-{1}', github.run_id, strategy.job-index) || format('results-{0}-{1}', github.run_id, strategy.job-index) }}
         path: |


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Two composite actions (`campaign-finalize-per-repo`, `campaign-finalize-issue-per-repo`) still used `actions/upload-artifact@v6` while the main workflows were updated to v7 via Dependabot PR #155. Dependabot missed these because `dependabot.yml` only scanned `.github/workflows/`, not subdirectories containing composite actions.

This PR:
- Bumps both composite actions from `upload-artifact@v6` to `@v7`
- Extends `dependabot.yml` with entries for both composite action directories so future updates are tracked automatically

#### Which issue(s) this PR fixes:

N/A (dependency maintenance)

#### Special notes for reviewers:

- Cross-version v6↔v7 is functionally compatible — no behavioral change expected.
- The `dependencies` and `github-actions` labels have been created on this repository for Dependabot to use.

#### Changelog input

```
 release-note
N/A
```

#### Additional documentation

```
docs
N/A
```