### PR TITLE
fix(campaign): split git add to prevent atomic failure on missing files

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -279,7 +279,11 @@ jobs:
         shell: bash
         working-directory: repo
         run: |
-          git add .github/workflows/release-automation.yml CHANGELOG.md CHANGELOG/README.md 2>/dev/null || true
+          # Add each file separately — a single git add with a missing pathspec
+          # (e.g. CHANGELOG.md absent) causes an atomic failure that stages nothing
+          git add .github/workflows/release-automation.yml 2>/dev/null || true
+          git add CHANGELOG.md 2>/dev/null || true
+          git add CHANGELOG/README.md 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -121,7 +121,11 @@ runs:
         fi
 
         # Compare against main (stage files first to detect new files)
-        git add ${{ inputs.target_files }} 2>/dev/null || true
+        # Add each file separately — a single git add with a missing pathspec
+        # (e.g. CHANGELOG.md absent) causes an atomic failure that stages nothing
+        for f in ${{ inputs.target_files }}; do
+          git add "$f" 2>/dev/null || true
+        done
         if git diff --cached --quiet -- ${{ inputs.target_files }}; then
           echo "No changes vs main → noop"
           echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes the onboarding campaign silently skipping PR creation for repositories that have no `CHANGELOG.md` file (e.g. IoTSIMFraudPrevention).

**Root cause:** `git add file1 file2 file3` fails atomically when any pathspec doesn't match a file. When `CHANGELOG.md` is absent, the entire `git add` exits with a fatal error — staging nothing, not even files that do exist. The `2>/dev/null || true` suppresses the error, so the subsequent `git diff --cached --quiet` sees zero staged files and reports `changed=false`, causing the workflow to skip PR creation.

**Fix:** Split into per-file `git add` calls so one missing file doesn't block the others.

Affected files:
- `.github/workflows/campaign-release-automation-onboarding.yml` (Detect changes step)
- `actions/campaign-finalize-per-repo/action.yml` (change_check step)

#### Which issue(s) this PR fixes:

Observed in run https://github.com/camaraproject/project-administration/actions/runs/23292745286

#### Special notes for reviewers:

The commit step in campaign-finalize-per-repo (line 222) already used the correct per-file pattern with existence checks. Only the change-detection `git add` calls had this bug.

#### Changelog input

```
release-note
N/A (internal tooling)
```

#### Additional documentation

This section can be blank.

```
docs

```