### PR TITLE
fix(progress-tracker): exclude archived and split repos from headline KPI

### DIFF
--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -39,7 +39,15 @@ properties:
         pattern: "^\\d+\\.\\d+\\.\\d+$"
       repos_scanned:
         type: integer
-        description: Total repositories checked
+        description: |
+          Active API repositories checked — total minus archived
+          (repository_archived) and minus umbrella repos that were split
+          into sub-APIs.
+      repos_new:
+        type: integer
+        description: |
+          Active repositories with no release (latest_public_release and
+          newest_pre_release both null) and no release-plan.yaml.
       repos_with_plan:
         type: integer
         description: Repositories with release-plan.yaml

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -52,6 +52,16 @@ from .warnings import generate_warnings
 
 logger = logging.getLogger(__name__)
 
+# Repositories that have been split into sub-APIs and will not receive new
+# release-plan.yaml entries. Historical releases remain visible in the table
+# because they flow through all_releases, not the filtered repositories list.
+# EdgeCloud is listed defensively — it is not currently in releases-master.yaml.
+SPLIT_REPOSITORIES = frozenset({
+    "EdgeCloud",
+    "DeviceStatus",
+    "KnowYourCustomer",
+})
+
 
 def load_releases_master(path: str) -> Dict:
     """Load releases-master.yaml from disk."""
@@ -479,8 +489,23 @@ def collect_all(
         api = GitHubAPI()
 
     master = load_releases_master(master_path)
-    repositories = master.get("repositories", [])
+    all_repositories = master.get("repositories", [])
     all_releases = master.get("releases", [])
+
+    def _is_active(repo: Dict) -> bool:
+        if repo.get("repository_archived", False):
+            return False
+        if repo.get("repository", "") in SPLIT_REPOSITORIES:
+            return False
+        return True
+
+    repositories = [r for r in all_repositories if _is_active(r)]
+    excluded_count = len(all_repositories) - len(repositories)
+    if excluded_count:
+        logger.info(
+            "Excluded %d repositories from active count (archived or split)",
+            excluded_count,
+        )
 
     context_map = build_published_context_map(repositories)
     repo_url_map: Dict[str, str] = {
@@ -525,6 +550,16 @@ def collect_all(
         except Exception as e:
             logger.warning("%s: collection failed: %s", repo_name, e)
             continue
+
+    # Count active repos that have no release-plan.yaml AND no published/pre releases.
+    # These are freshly-created repos not yet onboarded.
+    plan_repo_names = {e.repository for e in entries}
+    stats.repos_new = sum(
+        1 for r in repositories
+        if r.get("repository", "") not in plan_repo_names
+        and r.get("latest_public_release") is None
+        and r.get("newest_pre_release") is None
+    )
 
     # Add historical entries for repos with cycle releases but no release-plan.yaml
     active_repo_meta_releases = {
@@ -598,10 +633,10 @@ def collect_all(
         yaml.dump(output, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
     logger.info(
-        "Collection complete: %d repos scanned, %d with plan, %d planned, "
+        "Collection complete: %d repos scanned, %d new, %d with plan, %d planned, "
         "%d API calls in %.1fs, data_changed=%s",
-        stats.repos_scanned, stats.repos_with_plan, stats.repos_planned,
-        stats.api_calls, stats.duration_seconds, data_changed,
+        stats.repos_scanned, stats.repos_new, stats.repos_with_plan,
+        stats.repos_planned, stats.api_calls, stats.duration_seconds, data_changed,
     )
 
     return progress_data

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -208,6 +208,7 @@ class CollectionStats:
     repos_planned: int = 0
     repos_fully_onboarded: int = 0
     repos_with_release_issue: int = 0
+    repos_new: int = 0
     api_calls: int = 0
     duration_seconds: float = 0.0
 
@@ -218,6 +219,7 @@ class CollectionStats:
             "repos_planned": self.repos_planned,
             "repos_fully_onboarded": self.repos_fully_onboarded,
             "repos_with_release_issue": self.repos_with_release_issue,
+            "repos_new": self.repos_new,
             "api_calls": self.api_calls,
             "duration_seconds": round(self.duration_seconds, 1),
         }
@@ -245,6 +247,7 @@ class ProgressData:
                 "schema_version": self.schema_version,
                 "collector_version": self.collector_version,
                 "repos_scanned": self.collection_stats.repos_scanned,
+                "repos_new": self.collection_stats.repos_new,
                 "repos_with_plan": self.collection_stats.repos_with_plan,
                 "repos_fully_onboarded": self.collection_stats.repos_fully_onboarded,
                 "repos_with_release_issue": self.collection_stats.repos_with_release_issue,

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -454,12 +454,12 @@ tr.historical-row:hover td {
           : `${trackFilter} release cycle`;
       } else {
         const meta = PROGRESS_DATA.metadata;
-        headerDiv.innerHTML = [
-          `${meta.repos_scanned} repos`,
-          `${meta.repos_with_plan} with release-plan`,
-          `${meta.repos_fully_onboarded || 0} with ra workflow`,
-          `${meta.repos_with_release_issue || 0} with active release issue`,
-        ].join(' \u00b7 ');
+        headerDiv.innerHTML =
+          `automation progress: ${meta.repos_scanned} active` +
+          ` (${meta.repos_new || 0} new) \u00b7 ` +
+          `${meta.repos_with_plan} release-plan ` +
+          `(${meta.repos_fully_onboarded || 0} release automation` +
+          ` \u00b7 ${meta.repos_with_release_issue || 0} release issue)`;
       }
     }
 

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -1011,3 +1011,148 @@ class TestKPIStatistics:
         assert "repos_with_release_issue" in meta
         assert isinstance(meta["repos_fully_onboarded"], int)
         assert isinstance(meta["repos_with_release_issue"], int)
+
+
+class TestExcludeArchivedAndSplit:
+    """PA#201: archived and split umbrella repos must not inflate the active count."""
+
+    def _master(self):
+        return {
+            "metadata": SAMPLE_MASTER["metadata"],
+            "repositories": [
+                {
+                    "repository": "ActivePlanned",
+                    "github_url": "https://github.com/camaraproject/ActivePlanned",
+                    "latest_public_release": "r3.2",
+                    "newest_pre_release": None,
+                },
+                {
+                    "repository": "BrandNew",
+                    "github_url": "https://github.com/camaraproject/BrandNew",
+                    "latest_public_release": None,
+                    "newest_pre_release": None,
+                },
+                {
+                    "repository": "ArchivedWithHistory",
+                    "github_url": "https://github.com/camaraproject/ArchivedWithHistory",
+                    "repository_archived": True,
+                    "latest_public_release": "r1.2",
+                    "newest_pre_release": None,
+                },
+                {
+                    "repository": "ArchivedEmpty",
+                    "github_url": "https://github.com/camaraproject/ArchivedEmpty",
+                    "repository_archived": True,
+                    "latest_public_release": None,
+                    "newest_pre_release": None,
+                },
+                {
+                    # In SPLIT_REPOSITORIES → excluded from active count
+                    "repository": "DeviceStatus",
+                    "github_url": "https://github.com/camaraproject/DeviceStatus",
+                    "latest_public_release": "r2.2",
+                    "newest_pre_release": None,
+                },
+            ],
+            "releases": [
+                {
+                    "repository": "ActivePlanned",
+                    "release_tag": "r3.2",
+                    "release_date": "2025-11-15T10:00:00Z",
+                    "meta_release": "Fall25",
+                    "release_type": "public-release",
+                    "github_url": "https://github.com/camaraproject/ActivePlanned/releases/tag/r3.2",
+                    "apis": [{"api_name": "active-planned", "api_version": "1.0.0"}],
+                },
+                {
+                    "repository": "ArchivedWithHistory",
+                    "release_tag": "r1.2",
+                    "release_date": "2024-10-15T10:00:00Z",
+                    "meta_release": "Fall24",
+                    "release_type": "public-release",
+                    "github_url": "https://github.com/camaraproject/ArchivedWithHistory/releases/tag/r1.2",
+                    "apis": [{"api_name": "archived-api", "api_version": "1.0.0"}],
+                },
+                {
+                    "repository": "DeviceStatus",
+                    "release_tag": "r2.2",
+                    "release_date": "2025-03-14T11:49:32Z",
+                    "meta_release": "Spring25",
+                    "release_type": "public-release",
+                    "github_url": "https://github.com/camaraproject/DeviceStatus/releases/tag/r2.2",
+                    "apis": [{"api_name": "device-reachability-status", "api_version": "1.0.0"}],
+                },
+            ],
+        }
+
+    def test_scanned_count_excludes_archived_and_split(self, tmp_path):
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(self._master()))
+
+        api = MockGitHubAPI(
+            file_contents={"ActivePlanned/release-plan.yaml": PLAN_RC},
+        )
+        result = collect_all(str(master_file), str(output_file), api=api)
+
+        # 5 repos in master; 2 archived + 1 split → 2 active
+        assert result.collection_stats.repos_scanned == 2
+        assert result.collection_stats.repos_with_plan == 1
+
+    def test_brand_new_counted(self, tmp_path):
+        """Active repos with no release and no plan count as 'new'."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(self._master()))
+
+        api = MockGitHubAPI(
+            file_contents={"ActivePlanned/release-plan.yaml": PLAN_RC},
+        )
+        result = collect_all(str(master_file), str(output_file), api=api)
+
+        # BrandNew has no plan and no releases → +1 new
+        # ActivePlanned has a plan → not new
+        # Archived/split repos are filtered out entirely
+        assert result.collection_stats.repos_new == 1
+
+    def test_historical_releases_preserved_for_excluded_repos(self, tmp_path):
+        """Archived and split repos still contribute historical entries."""
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(self._master()))
+
+        api = MockGitHubAPI(
+            file_contents={"ActivePlanned/release-plan.yaml": PLAN_RC},
+        )
+        result = collect_all(str(master_file), str(output_file), api=api)
+
+        repos_in_progress = {e.repository for e in result.progress}
+        assert "ArchivedWithHistory" in repos_in_progress
+        assert "DeviceStatus" in repos_in_progress
+        # No releases → no historical entry
+        assert "ArchivedEmpty" not in repos_in_progress
+
+        archived_entry = next(
+            e for e in result.progress if e.repository == "ArchivedWithHistory"
+        )
+        assert archived_entry.state == ProgressState.HISTORICAL
+        split_entry = next(
+            e for e in result.progress if e.repository == "DeviceStatus"
+        )
+        assert split_entry.state == ProgressState.HISTORICAL
+
+    def test_repos_new_in_serialized_metadata(self, tmp_path):
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(self._master()))
+
+        api = MockGitHubAPI(
+            file_contents={"ActivePlanned/release-plan.yaml": PLAN_RC},
+        )
+        collect_all(str(master_file), str(output_file), api=api)
+
+        output = yaml.safe_load(output_file.read_text())
+        meta = output["metadata"]
+        assert meta["repos_scanned"] == 2
+        assert meta["repos_new"] == 1
+        assert isinstance(meta["repos_new"], int)

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -141,7 +141,7 @@ class TestProgressData:
             last_checked="2026-03-15T10:00:00Z",
             releases_master_updated="2026-03-15T04:35:00Z",
             collection_stats=CollectionStats(
-                repos_scanned=63, repos_with_plan=45,
+                repos_scanned=62, repos_new=9, repos_with_plan=45,
                 repos_planned=38, api_calls=200, duration_seconds=95.3,
             ),
             meta_releases=[
@@ -162,7 +162,8 @@ class TestProgressData:
         assert d["metadata"]["last_checked"] == "2026-03-15T10:00:00Z"
         assert d["metadata"]["releases_master_updated"] == "2026-03-15T04:35:00Z"
         assert "collection_stats" not in d["metadata"]  # Full stats removed from output
-        assert d["metadata"]["repos_scanned"] == 63     # Stable stats restored
+        assert d["metadata"]["repos_scanned"] == 62     # Stable stats restored
+        assert d["metadata"]["repos_new"] == 9
         assert d["metadata"]["repos_with_plan"] == 45
         assert len(d["meta_releases"]) == 1
         assert d["meta_releases"][0]["name"] == "Sync26"


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Rewrites the Release Progress Tracker headline KPI so it no longer inflates the active-funnel count with repositories that will never receive a `release-plan.yaml`.

New headline format:

```
automation progress: XX active (YY new) · ZZ release-plan (AA release automation · BB release issue)
```

Against current upstream data:

```
automation progress: 62 active (6 new) · 54 release-plan (8 release automation · 4 release issue)
```

Changes:

- **`collect_progress.py`**: introduces `SPLIT_REPOSITORIES` const (`EdgeCloud`, `DeviceStatus`, `KnowYourCustomer`) and filters out `repository_archived: true` repos plus split umbrella repos from `repos_scanned` and the scan loop. Adds a `repos_new` stat for active repos that have neither a release nor a `release-plan.yaml`.
- **`models.py`** / **`releases-progress-schema.yaml`**: adds `repos_new` to `CollectionStats` and the serialized metadata.
- **`progress-template.html`**: rewrites the unfiltered branch of `updateHeader()` to the new format.
- **Tests**: 4 new cases covering the filter, the new-count, historical-entry preservation for excluded repos, and metadata round-trip.

Historical releases from excluded repos remain visible in the table because `collect_historical_entries()` iterates `all_releases` rather than the filtered `repositories` list. Verified end-to-end against upstream `releases-master.yaml`:

- HomeDevicesQoD Fall24 → historical entry preserved
- DeviceStatus Spring25/earlier → historical entries preserved
- KnowYourCustomer r2.x → historical entries preserved
- ShortMessageService, SiteToCloudVPN → correctly absent (no releases)

Why a const list for split repos: `releases-master.yaml` has no repository-level marker for "superseded by split into sub-repos", and adding a new schema field just for 3 entries would be overkill.

#### Which issue(s) this PR fixes:

Fixes #201

#### Special notes for reviewers:

- Fork-tested via a temporary `test/progress-tracker-pa201` branch that pointed the reusable workflow's `SOURCE_REPO`/`SOURCE_REF` at the fork; that branch has been deleted.
- Full local pytest suite: 141 passed (137 pre-existing + 4 new).
- Real-data E2E via the collector produced the numbers shown above and the expected historical-entry behavior.

#### Changelog input

```
 release-note
fix(progress-tracker): headline KPI now excludes archived and split umbrella repositories and reports a new-repo count
```

#### Additional documentation

This section can be blank.

```
docs

```