### PR TITLE
chore: migrate campaign workflows from app-id to client-id

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -14,7 +14,7 @@
 # AUTHENTICATION:
 # - select job: uses GITHUB_TOKEN (read-only, public repos)
 # - run job: uses camara-release-automation GitHub App token via create-github-app-token action
-#   Requires org-level variable RELEASE_APP_ID and secret RELEASE_APP_PRIVATE_KEY
+#   Requires org-level variable RELEASE_APP_CLIENT_ID and secret RELEASE_APP_PRIVATE_KEY
 #
 # NOTE: Repository rulesets require admin-level access and are applied separately
 # via the apply-release-rulesets.sh script.
@@ -163,7 +163,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/campaign-release-info.yml
+++ b/.github/workflows/campaign-release-info.yml
@@ -6,7 +6,7 @@
 #
 # AUTHENTICATION:
 # - run job: uses camara-release-automation GitHub App token via create-github-app-token action
-#   Requires org-level variable RELEASE_APP_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
+#   Requires org-level variable RELEASE_APP_CLIENT_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
 #
 # CHANGELOG:
 # - 2024-12-17: Standardized header format
@@ -153,7 +153,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/campaign-release-plan-rollout.yml
+++ b/.github/workflows/campaign-release-plan-rollout.yml
@@ -7,7 +7,7 @@
 # AUTHENTICATION:
 # - select job: uses GITHUB_TOKEN (read-only, public repos)
 # - run job: uses camara-release-automation GitHub App token via create-github-app-token action
-#   Requires org-level variable RELEASE_APP_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
+#   Requires org-level variable RELEASE_APP_CLIENT_ID, RELEASE_APP_SLUG and secret RELEASE_APP_PRIVATE_KEY
 #
 # DOCUMENTATION:
 # https://github.com/camaraproject/project-administration/blob/main/campaigns/release-plan-rollout/docs/README.md
@@ -221,7 +221,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -185,10 +185,10 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Migrates the four campaign / utility workflows from the deprecated `app-id:` input to `client-id:` on `actions/create-github-app-token@v3`. Brings PA in line with the tooling repo's workflows (migrated in camaraproject/tooling#158) and unblocks eventual cleanup of the legacy `RELEASE_APP_ID` org variable.

Changes per file:
- `campaign-release-automation-onboarding.yml`: header comment + `app-id` → `client-id`
- `campaign-release-info.yml`: header comment + `app-id` → `client-id`
- `campaign-release-plan-rollout.yml`: header comment + `app-id` → `client-id`
- `release-progress-tracker.yml`: two app-token steps (`if:` gate + `app-id:`) → `client-id` form

Private key (`RELEASE_APP_PRIVATE_KEY`) and installation unchanged.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for reviewers:

`RELEASE_APP_CLIENT_ID` org variable is already in use by tooling workflows (`release-automation-reusable.yml`, `validation.yml`, `regression-runner.yml`). YAML parses cleanly. End-to-end token-minting will be validated by the first post-merge dispatch of `campaign-release-automation-onboarding` in `plan` mode.

#### Changelog input

\`\`\`
 release-note
 none
\`\`\`

#### Additional documentation

This section can be blank.

\`\`\`
docs
none
\`\`\`