### PR TITLE
feat(campaigns): reconciliation action for ongoing caller updates

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -1,15 +1,17 @@
 # =========================================================================================
-# CAMARA Project - Campaign: Release Automation + Validation Onboarding
+# CAMARA Project - Campaign: Release Automation + Validation Reconciliation
 #
-# Onboards API repositories to the CAMARA release automation and installs the
-# CAMARA Validation workflow alongside it:
+# Reconciles API repositories with the canonical release-automation and
+# CAMARA Validation caller workflows hosted in camaraproject/tooling:
 # - Release automation caller (.github/workflows/release-automation.yml)
 # - CAMARA Validation caller  (.github/workflows/camara-validation.yml)
 # - CHANGELOG directory structure (CHANGELOG/README.md)
 # - Removes unchanged template CHANGELOG.md or adds forward-reference note to real ones
 #
-# Creates PRs for repositories that have release-plan.yaml. Already-onboarded
-# repos are handled idempotently: change detection skips unchanged files.
+# Covers both initial onboarding (fresh install) and ongoing caller updates
+# on a STABLE branch per repo. Idempotent: reruns force-push updates to the
+# same branch/PR, close the PR when the repo is in sync, or abort on non-bot
+# commits. See actions/campaign-reconcile-per-repo/README.md for details.
 #
 # AUTHENTICATION:
 # - select job: uses GITHUB_TOKEN (read-only, public repos)
@@ -23,7 +25,7 @@
 # See release_automation/docs/repository-setup.md in camaraproject/tooling
 # =========================================================================================
 
-name: Campaign - Release Automation + Validation Onboarding
+name: Campaign - Release Automation + Validation Reconciliation
 
 on:
   workflow_dispatch:
@@ -53,7 +55,7 @@ on:
         default: 'v1-rc'
 
 concurrency:
-  group: campaign-release-automation-onboarding-${{ github.ref }}
+  group: campaign-release-automation-reconciliation-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -62,8 +64,10 @@ env:
   INCLUDE: ${{ inputs.include }}
   CALLER_REF: ${{ inputs.caller_ref }}
   VALIDATION_REF: ${{ inputs.validation_ref }}
-  BRANCH: bulk/release-automation-onboarding-${{ github.run_id }}
-  PR_TITLE: "[bulk] Enable release automation and validation"
+  # Stable branch — reconcile action reuses it across dispatches.
+  # PR title is decided per-repo (initial onboarding vs caller update) in
+  # the mode_state step.
+  BRANCH: camara/release-automation-update
   # Source location of the caller workflow templates in camaraproject/tooling
   CALLER_TEMPLATE_PATH: release_automation/workflows/release-automation-caller.yml
   VALIDATION_TEMPLATE_PATH: validation/workflows/validation-caller.yml
@@ -144,8 +148,10 @@ jobs:
             core.setOutput('repos', JSON.stringify(eligible));
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 2: Per-repo onboarding (matrix)
-  # Adds release automation caller, CAMARA Validation caller, CHANGELOG structure
+  # Job 2: Per-repo reconciliation (matrix)
+  # Builds the target template state (release-automation caller, validation
+  # caller, CHANGELOG structure) into repo/, then delegates to the
+  # campaign-reconcile-per-repo action for branch/PR handling.
   # ─────────────────────────────────────────────────────────────────────────────
   run:
     needs: select
@@ -179,6 +185,24 @@ jobs:
           path: repo
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Detect initial onboarding vs caller update
+        id: mode_state
+        shell: bash
+        run: |
+          # Classify the run: initial onboarding if the release-automation
+          # caller doesn't yet exist on main, otherwise a caller update.
+          if [ -f repo/.github/workflows/release-automation.yml ]; then
+            echo "is_initial=false" >> $GITHUB_OUTPUT
+            echo "pr_title=[bulk] Update release-automation + validation callers" >> $GITHUB_OUTPUT
+            echo "pr_body_template=admin/campaigns/release-automation-onboarding/templates/pr-body-update.mustache" >> $GITHUB_OUTPUT
+            echo "Repo already onboarded — this is a caller-update run."
+          else
+            echo "is_initial=true" >> $GITHUB_OUTPUT
+            echo "pr_title=[bulk] Enable release automation and validation" >> $GITHUB_OUTPUT
+            echo "pr_body_template=admin/campaigns/release-automation-onboarding/templates/pr-body.mustache" >> $GITHUB_OUTPUT
+            echo "Repo not yet onboarded — this is an initial onboarding run."
+          fi
 
       - name: Fetch caller workflow template from tooling
         id: fetch_caller
@@ -309,24 +333,31 @@ jobs:
             echo "warning=No README.md found" >> $GITHUB_OUTPUT
           fi
 
-      - name: Detect changes
-        id: changes
+      - name: Generate change summary (caller update variant)
+        id: change_summary
+        if: ${{ steps.mode_state.outputs.is_initial == 'false' }}
         shell: bash
         working-directory: repo
         run: |
-          # Add each file separately — a single git add with a missing pathspec
-          # (e.g. CHANGELOG.md absent) causes an atomic failure that stages nothing
-          git add .github/workflows/release-automation.yml 2>/dev/null || true
-          git add .github/workflows/camara-validation.yml 2>/dev/null || true
-          git add CHANGELOG.md 2>/dev/null || true
-          git add CHANGELOG/README.md 2>/dev/null || true
-          if git diff --cached --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "Changes detected:"
-            git diff --cached --name-only
-          fi
+          # Stage target files and capture a compact diff stat for the PR body.
+          # Only fires on the update variant — the initial onboarding body has
+          # its own static "Changes" table. Full diff is available on the PR's
+          # Files changed tab, so we don't thread it into the body.
+          for f in .github/workflows/release-automation.yml \
+                   .github/workflows/camara-validation.yml \
+                   CHANGELOG.md \
+                   CHANGELOG/README.md; do
+            git add "$f" 2>/dev/null || true
+          done
+
+          {
+            echo 'stat<<EOF'
+            git diff --cached --stat || true
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+          echo "Caller update diff stat:"
+          git diff --cached --stat || true
 
       - name: Configure git identity
         if: ${{ env.MODE == 'apply' }}
@@ -341,6 +372,9 @@ jobs:
       - name: Build campaign data JSON
         id: campaign_data
         shell: bash
+        env:
+          IS_INITIAL: ${{ steps.mode_state.outputs.is_initial }}
+          CHANGE_STAT: ${{ steps.change_summary.outputs.stat }}
         run: |
           REPO_NAME=$(echo "${{ matrix.repo }}" | cut -d'/' -f2)
           README_WARNING="${{ steps.readme_check.outputs.warning }}"
@@ -377,6 +411,9 @@ jobs:
             HAS_WARNINGS="true"
           fi
 
+          # IS_INITIAL / CHANGE_STAT are injected via env (see above)
+          # so quote characters in the diff cannot break shell parsing.
+
           JSON=$(jq -n \
             --arg repo "${{ matrix.repo }}" \
             --arg name "$REPO_NAME" \
@@ -387,6 +424,8 @@ jobs:
             --arg changelog_dir_status "$CHANGELOG_DIR_STATUS" \
             --argjson has_warnings "$HAS_WARNINGS" \
             --arg warnings "$WARNINGS" \
+            --argjson is_initial "$IS_INITIAL" \
+            --arg change_stat "$CHANGE_STAT" \
             '{
               repo: $repo,
               name: $name,
@@ -396,7 +435,9 @@ jobs:
               changelog_root_status: $changelog_root_status,
               changelog_dir_status: $changelog_dir_status,
               has_warnings: $has_warnings,
-              warnings: $warnings
+              warnings: $warnings,
+              is_initial: $is_initial,
+              change_stat: $change_stat
             }')
           echo "json<<EOF" >> $GITHUB_OUTPUT
           echo "$JSON" >> $GITHUB_OUTPUT
@@ -406,18 +447,17 @@ jobs:
         id: pr_body
         uses: ./admin/actions/render-mustache
         with:
-          template: admin/campaigns/release-automation-onboarding/templates/pr-body.mustache
+          template: ${{ steps.mode_state.outputs.pr_body_template }}
           data_json: ${{ steps.campaign_data.outputs.json }}
           out_file: /tmp/pr-body.md
 
-      - name: Campaign finalize
-        uses: ./admin/actions/campaign-finalize-per-repo
+      - name: Campaign reconcile
+        uses: ./admin/actions/campaign-reconcile-per-repo
         with:
           mode: ${{ env.MODE }}
-          changed: ${{ steps.changes.outputs.changed }}
           repo: ${{ matrix.repo }}
           campaign_data: ${{ steps.campaign_data.outputs.json }}
-          pr_base_title: ${{ env.PR_TITLE }}
+          pr_title: ${{ steps.mode_state.outputs.pr_title }}
           pr_body_file: /tmp/pr-body.md
           branch: ${{ env.BRANCH }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -464,7 +504,7 @@ jobs:
             const baseName = '${{ steps.pattern.outputs.base_name }}';
 
             const header = [
-              '# Release Automation + Validation Onboarding Campaign - Summary',
+              '# Release Automation + Validation Reconciliation Campaign - Summary',
               '',
               `Generated: ${new Date().toISOString()}`,
               `Mode: ${mode}`,
@@ -526,6 +566,6 @@ jobs:
 
       - name: Add workflow summary
         run: |
-          echo "## Release Automation + Validation Onboarding Campaign - Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Release Automation + Validation Reconciliation Campaign - Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           cat ${{ steps.pattern.outputs.base_name }}.md >> $GITHUB_STEP_SUMMARY

--- a/actions/campaign-reconcile-per-repo/README.md
+++ b/actions/campaign-reconcile-per-repo/README.md
@@ -1,0 +1,78 @@
+# campaign-reconcile-per-repo
+
+Per-repo finalization for **reconciliation** campaigns. Sibling to
+[`campaign-finalize-per-repo`](../campaign-finalize-per-repo/), focused on
+ongoing rollout of a canonical template (caller workflows, shared configs,
+etc.) to already-onboarded repositories.
+
+## Behaviour
+
+The caller workflow has already built the target template state into the
+`repo/` working tree (e.g. fetched a caller workflow file from
+`camaraproject/tooling` into `repo/.github/workflows/...`). This action
+takes it from there.
+
+| Repo state (after caller built `repo/`) | Existing PR on stable branch? | Outcome |
+|--|--|--|
+| In sync (no diff vs main) | no  | No-op. |
+| In sync (no diff vs main) | yes | Close the PR with a comment — repo is now in sync. |
+| Drift vs main | no  | Push a fresh branch built from main + template, open PR with stable title. |
+| Drift vs main | yes, branch HEAD is bot-authored | Rebuild branch from main + template, `git push --force-with-lease`. Existing PR updates automatically; no second PR. |
+| Drift vs main | yes, branch HEAD has **non-bot** commits | Abort. Operator merges or closes the PR first. Next run either reconciles cleanly (if merged to main) or waits for the branch to be reclaimed. |
+
+The stable **branch name** and **PR title** are inputs — reusable for any
+template-propagation campaign.
+
+## Contract with the caller workflow
+
+- Caller checks out the target repo to `repo/` with `fetch-depth: 0` and
+  an app token for `origin`.
+- Caller configures git identity (bot name + noreply email) before
+  calling this action.
+- Caller has written the desired target state into `repo/` (e.g. copied
+  a file from the template source).
+- This action compares the working tree against `main`, chooses the right
+  outcome (create / update / close / no-op / abort), and records a
+  per-repo artifact row.
+
+## Comparison with `campaign-finalize-per-repo`
+
+- **finalize** uses a run-id-unique branch per dispatch and a date-stamped
+  PR title (`... ($DATE-NNN)`). Skips any repo with an existing campaign
+  PR — a new dispatch creates a fresh branch next time.
+- **reconcile** uses a stable branch + stable PR title. Reruns
+  force-push updates to the same PR, or close it when the repo matches
+  the template. No PR churn.
+
+Keep using **finalize** for one-shot migrations (e.g. adding
+`release-plan.yaml` once per repo). Use **reconcile** for ongoing
+template maintenance (e.g. caller workflow bumps).
+
+## Safety model
+
+- `--force-with-lease` on push — aborts if `origin` moved since last fetch.
+- Non-bot commit guard — examines commits between the stable branch and
+  `main` and aborts if any commit's author email does not match
+  `bot_email_pattern` (default: `^[0-9]+\+.*\[bot\]@users\.noreply\.github\.com$`).
+- The action **does not** configure git identity — caller's responsibility.
+
+## Inputs
+
+See `action.yml` for the full schema. Key fields:
+
+- `branch` — stable branch name (e.g. `camara/release-automation-update`).
+- `pr_title` — stable PR title.
+- `target_files` — space-separated list of files the caller built into
+  `repo/`.
+- `bot_email_pattern` — override if the bot identity differs from the
+  CAMARA default.
+
+## Outputs (artifact fields)
+
+Each per-repo run records a JSONL row with:
+
+- `pr_status`: `will_create` | `will_update_existing` | `will_close_stale` | `no_change` | `aborted`
+- `reason`: `new_changes` | `in_sync` | `non_bot_commits_on_branch` | `error`
+- `pr_number`, `pr_url` (if applicable)
+- `non_bot_shas` (only on abort)
+- Any campaign-specific fields threaded through `campaign_data`

--- a/actions/campaign-reconcile-per-repo/action.yml
+++ b/actions/campaign-reconcile-per-repo/action.yml
@@ -1,0 +1,390 @@
+# =========================================================================================
+# CAMARA Project - Action: Campaign Reconcile Per Repo
+#
+# Per-repo finalization for reconciliation campaigns. Reconciles a canonical
+# template (already built into the `repo/` working tree by earlier campaign
+# steps) with the target repository on a STABLE branch. Idempotent: reruns
+# force-push updates to the same branch and PR, no churn of fresh PRs.
+#
+# Behaviour vs. the adjacent campaign-finalize-per-repo action:
+# - Stable branch + stable PR title (caller-provided; no date / run-id suffix)
+# - No "existing PR → skip" — a stale PR on the stable branch is UPDATED
+#   via force-push, not superseded with a new one
+# - Non-bot commits on the stable branch abort the run (safety guard)
+# - When the template matches main (no diff), any open PR on the stable
+#   branch is closed with a comment — the repo is in sync
+#
+# Intended for ongoing caller-template rollout (initial onboarding is just
+# a big first diff) and future template bumps.
+# =========================================================================================
+name: 'Campaign Reconcile Per Repo'
+description: 'Reconciliation finalize for campaign workflows: stable branch, force-push, no-op close'
+inputs:
+  mode:
+    description: 'Workflow mode (plan or apply)'
+    required: true
+  repo:
+    description: 'Repository slug (org/repo)'
+    required: true
+  campaign_data:
+    description: 'JSON with campaign-specific data (same schema as finalize action)'
+    required: false
+    default: '{}'
+  pr_title:
+    description: 'Stable PR title (reused across runs for idempotent detection)'
+    required: true
+  pr_body_file:
+    description: 'Path to rendered PR body file (apply mode only)'
+    required: false
+    default: ''
+  branch:
+    description: 'Stable branch name (reused across runs; force-push target)'
+    required: true
+  github_token:
+    description: 'GitHub token for PR + branch operations (apply mode only)'
+    required: false
+    default: ''
+  target_files:
+    description: 'Files to reconcile (space-separated; built into repo/ by the caller)'
+    required: false
+    default: 'README.md'
+  label_name:
+    description: 'GitHub label for campaign PRs'
+    required: false
+    default: 'automated'
+  label_color:
+    description: 'Label color (hex without #)'
+    required: false
+    default: 'd1d5db'
+  label_description:
+    description: 'Label description'
+    required: false
+    default: 'Automated bulk operations from project-administration'
+  bot_email_pattern:
+    description: 'Regex matching the bot author email on allowed branch commits. Commits whose author email does NOT match abort the run.'
+    required: false
+    default: '^[0-9]+\+.*\[bot\]@users\.noreply\.github\.com$'
+  error_occurred:
+    description: 'Whether an error occurred in a prior workflow step'
+    required: false
+    default: 'false'
+  error_message:
+    description: 'Error message if error occurred'
+    required: false
+    default: ''
+  error_step:
+    description: 'Step where error occurred'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    # ─────────────────────────────────────────────────────────────────────
+    # 1. Detect existing PR on the stable branch
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Detect existing PR on stable branch
+      id: detect
+      if: ${{ inputs.error_occurred != 'true' }}
+      shell: bash
+      working-directory: repo
+      run: |
+        PR_JSON=$(gh pr list \
+          --head "${{ inputs.branch }}" \
+          --state open \
+          --json number,url,headRefName,headRefOid \
+          --jq '.[0] // {}')
+
+        PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty')
+        PR_URL=$(echo "$PR_JSON" | jq -r '.url // empty')
+        PR_HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid // empty')
+
+        if [ -n "$PR_NUMBER" ]; then
+          echo "pr_exists=true" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "Existing PR #$PR_NUMBER on branch '${{ inputs.branch }}': $PR_URL (head $PR_HEAD_SHA)"
+        else
+          echo "pr_exists=false" >> $GITHUB_OUTPUT
+          echo "No existing PR on branch '${{ inputs.branch }}'"
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 2. Verify existing branch commits are bot-authored
+    # Aborts if the stable branch has commits from a human author — the
+    # codeowner may be iterating on the PR and force-pushing would overwrite
+    # their work. Operator closes or merges the PR, then reruns.
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Verify branch commits are bot-authored
+      id: verify_authorship
+      if: ${{ inputs.error_occurred != 'true' && steps.detect.outputs.pr_exists == 'true' }}
+      shell: bash
+      working-directory: repo
+      run: |
+        PATTERN='${{ inputs.bot_email_pattern }}'
+        # Fetch just the branch tip + its path back to main
+        git fetch origin "${{ inputs.branch }}" || true
+        MERGE_BASE=$(git merge-base "origin/${{ inputs.branch }}" "origin/main" 2>/dev/null || true)
+        if [ -z "$MERGE_BASE" ]; then
+          echo "aborted=false" >> $GITHUB_OUTPUT
+          echo "non_bot_shas=" >> $GITHUB_OUTPUT
+          echo "No merge-base between branch and main; treating as bot-authored (fresh branch)."
+          exit 0
+        fi
+
+        NON_BOT_SHAS=$(git log --format='%H|%ae' "$MERGE_BASE..origin/${{ inputs.branch }}" \
+          | awk -F'|' -v pat="$PATTERN" '$2 !~ pat { print $1 }' \
+          | tr '\n' ' ')
+
+        if [ -n "${NON_BOT_SHAS// /}" ]; then
+          echo "aborted=true" >> $GITHUB_OUTPUT
+          echo "non_bot_shas=$NON_BOT_SHAS" >> $GITHUB_OUTPUT
+          echo "::warning::Non-bot commits on '${{ inputs.branch }}': $NON_BOT_SHAS"
+          echo "::warning::Reconciliation aborted for ${{ inputs.repo }} — close or merge PR #${{ steps.detect.outputs.pr_number }} first."
+        else
+          echo "aborted=false" >> $GITHUB_OUTPUT
+          echo "non_bot_shas=" >> $GITHUB_OUTPUT
+          echo "All branch commits are bot-authored; safe to force-push."
+        fi
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 3. Change detection vs main (source of truth)
+    # The caller has already built target_files into the working tree.
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Detect changes vs main
+      id: change_check
+      if: ${{ inputs.error_occurred != 'true' && steps.verify_authorship.outputs.aborted != 'true' }}
+      shell: bash
+      working-directory: repo
+      run: |
+        for f in ${{ inputs.target_files }}; do
+          git add "$f" 2>/dev/null || true
+        done
+        if git diff --cached --quiet -- ${{ inputs.target_files }}; then
+          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "reason=in_sync" >> $GITHUB_OUTPUT
+          echo "No diff vs main — repo is in sync with template."
+        else
+          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "reason=content_changed" >> $GITHUB_OUTPUT
+          echo "Diff vs main detected:"
+          git diff --cached --name-only
+        fi
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 4. Determine resulting pr_status (for outcome recording)
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Determine PR status
+      id: pr_status
+      if: ${{ inputs.error_occurred != 'true' }}
+      shell: bash
+      run: |
+        ABORTED="${{ steps.verify_authorship.outputs.aborted }}"
+        CHANGED="${{ steps.change_check.outputs.changed }}"
+        PR_EXISTS="${{ steps.detect.outputs.pr_exists }}"
+
+        if [ "$ABORTED" = "true" ]; then
+          STATUS="aborted"
+        elif [ "$CHANGED" = "true" ] && [ "$PR_EXISTS" = "true" ]; then
+          STATUS="will_update_existing"
+        elif [ "$CHANGED" = "true" ]; then
+          STATUS="will_create"
+        elif [ "$CHANGED" = "false" ] && [ "$PR_EXISTS" = "true" ]; then
+          STATUS="will_close_stale"
+        else
+          STATUS="no_change"
+        fi
+
+        echo "pr_status=$STATUS" >> $GITHUB_OUTPUT
+        echo "Resolved pr_status=$STATUS"
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 5. APPLY — ensure campaign label
+    # ─────────────────────────────────────────────────────────────────────
+    - name: APPLY - Ensure campaign label exists
+      if: |
+        inputs.mode == 'apply'
+        && inputs.error_occurred != 'true'
+        && steps.verify_authorship.outputs.aborted != 'true'
+        && (steps.change_check.outputs.changed == 'true'
+            || steps.detect.outputs.pr_exists == 'true')
+      shell: bash
+      working-directory: repo
+      run: |
+        if ! gh label list --json name --jq '.[].name' | grep -q "^${{ inputs.label_name }}$"; then
+          gh label create "${{ inputs.label_name }}" \
+            --description "${{ inputs.label_description }}" \
+            --color "${{ inputs.label_color }}"
+          echo "Label '${{ inputs.label_name }}' created"
+        else
+          echo "Label '${{ inputs.label_name }}' already exists"
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 6. APPLY — push updated content to the stable branch (force-with-lease)
+    # Rebuild branch from origin/main + the in-tree target_files.
+    # ─────────────────────────────────────────────────────────────────────
+    - name: APPLY - Force-push stable branch
+      id: push
+      if: |
+        inputs.mode == 'apply'
+        && inputs.error_occurred != 'true'
+        && steps.verify_authorship.outputs.aborted != 'true'
+        && steps.change_check.outputs.changed == 'true'
+      shell: bash
+      working-directory: repo
+      run: |
+        # Git identity is pre-configured by the caller workflow.
+        # Snapshot built target_files (working tree), then reset branch to main.
+        TMP_DIR="$(mktemp -d)"
+        for f in ${{ inputs.target_files }}; do
+          if [ -e "$f" ]; then
+            mkdir -p "$TMP_DIR/$(dirname "$f")"
+            cp "$f" "$TMP_DIR/$f"
+          fi
+        done
+
+        git fetch origin main
+        git checkout -B "${{ inputs.branch }}" origin/main
+
+        # Re-apply snapshot
+        for f in ${{ inputs.target_files }}; do
+          if [ -e "$TMP_DIR/$f" ]; then
+            mkdir -p "$(dirname "$f")"
+            cp "$TMP_DIR/$f" "$f"
+            git add "$f"
+          else
+            git rm -f --ignore-unmatch "$f"
+          fi
+        done
+
+        if git diff --cached --quiet; then
+          echo "Nothing to commit after rebuilding branch from main — skipping push."
+          echo "pushed=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        git commit -m "${{ inputs.pr_title }}"
+
+        # Use --force-with-lease to abort on concurrent remote changes.
+        # If the branch doesn't exist yet on origin, fall back to a regular push.
+        if git ls-remote --exit-code --heads origin "${{ inputs.branch }}" >/dev/null 2>&1; then
+          git push --force-with-lease origin "${{ inputs.branch }}"
+        else
+          git push origin "${{ inputs.branch }}"
+        fi
+
+        echo "pushed=true" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 7. APPLY — create PR (only if no PR on stable branch yet)
+    # Force-push on an existing PR updates it automatically.
+    # ─────────────────────────────────────────────────────────────────────
+    - name: APPLY - Create PR
+      id: pr_create
+      if: |
+        inputs.mode == 'apply'
+        && inputs.error_occurred != 'true'
+        && steps.verify_authorship.outputs.aborted != 'true'
+        && steps.change_check.outputs.changed == 'true'
+        && steps.push.outputs.pushed == 'true'
+        && steps.detect.outputs.pr_exists != 'true'
+      shell: bash
+      working-directory: repo
+      run: |
+        PR_URL=$(gh pr create \
+          --title "${{ inputs.pr_title }}" \
+          --body-file "${{ inputs.pr_body_file }}" \
+          --head "${{ inputs.branch }}" \
+          --base main \
+          --label "${{ inputs.label_name }}")
+        echo "created_pr_url=$PR_URL" >> $GITHUB_OUTPUT
+        echo "Created PR: $PR_URL"
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 8. APPLY — close stale PR when content is in sync
+    # ─────────────────────────────────────────────────────────────────────
+    - name: APPLY - Close stale PR (repo in sync)
+      id: pr_close
+      if: |
+        inputs.mode == 'apply'
+        && inputs.error_occurred != 'true'
+        && steps.verify_authorship.outputs.aborted != 'true'
+        && steps.change_check.outputs.changed == 'false'
+        && steps.detect.outputs.pr_exists == 'true'
+      shell: bash
+      working-directory: repo
+      run: |
+        gh pr comment "${{ steps.detect.outputs.pr_number }}" \
+          --body "Closing automatically — ${{ inputs.repo }} main is now in sync with the canonical template (reconciliation run detected no diff)."
+        gh pr close "${{ steps.detect.outputs.pr_number }}"
+        echo "Closed PR #${{ steps.detect.outputs.pr_number }} (repo in sync)"
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 9. Record outcome (markdown + jsonl artifact row)
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Record outcome
+      if: always()
+      shell: bash
+      run: |
+        node ${{ github.action_path }}/dist/index.js
+      env:
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_CAMPAIGN_DATA: ${{ inputs.campaign_data }}
+        INPUT_PR_STATUS: ${{ steps.pr_status.outputs.pr_status }}
+        INPUT_PR_NUMBER: ${{ steps.detect.outputs.pr_number }}
+        INPUT_PR_URL: ${{ steps.pr_create.outputs.created_pr_url || steps.detect.outputs.pr_url }}
+        INPUT_NON_BOT_SHAS: ${{ steps.verify_authorship.outputs.non_bot_shas }}
+        INPUT_ERROR_OCCURRED: ${{ inputs.error_occurred }}
+        INPUT_ERROR_MESSAGE: ${{ inputs.error_message }}
+        INPUT_ERROR_STEP: ${{ inputs.error_step }}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 10. PLAN mode — copy generated target files for plan artifact
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Copy generated files for plan artifact
+      if: ${{ inputs.mode == 'plan' }}
+      shell: bash
+      run: |
+        mkdir -p plan-files
+        for file in ${{ inputs.target_files }}; do
+          if [ -f "repo/$file" ]; then
+            mkdir -p "plan-files/$(dirname "$file")"
+            cp "repo/$file" "plan-files/$file"
+          fi
+        done
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 11. PLAN mode — reset working tree
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Reset repo (plan mode)
+      if: ${{ inputs.mode == 'plan' }}
+      shell: bash
+      working-directory: repo
+      run: |
+        git reset --hard
+        git clean -fd
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 12. Upload artifacts (plan.md/jsonl or results.md/jsonl + plan-files)
+    # ─────────────────────────────────────────────────────────────────────
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.mode == 'plan' && format('plan-{0}-{1}', github.run_id, strategy.job-index) || format('results-{0}-{1}', github.run_id, strategy.job-index) }}
+        path: |
+          ${{ inputs.mode == 'plan' && 'plan' || 'results' }}.md
+          ${{ inputs.mode == 'plan' && 'plan' || 'results' }}.jsonl
+          ${{ inputs.mode == 'plan' && 'plan-files/**' || '' }}

--- a/actions/campaign-reconcile-per-repo/dist/index.js
+++ b/actions/campaign-reconcile-per-repo/dist/index.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+
+function getInput(name) {
+  return process.env[`INPUT_${name.toUpperCase()}`] || '';
+}
+
+try {
+  const repo = getInput('repo');
+  const mode = getInput('mode');
+  const campaignDataStr = getInput('campaign_data') || '{}';
+  const prStatus = getInput('pr_status');
+  const prNumber = getInput('pr_number');
+  const prUrl = getInput('pr_url');
+  const nonBotShas = getInput('non_bot_shas').trim();
+  const errorOccurred = getInput('error_occurred') === 'true';
+  const errorMessage = getInput('error_message');
+  const errorStep = getInput('error_step');
+
+  const campaignData = JSON.parse(campaignDataStr);
+  const outputName = mode === 'plan' ? 'plan' : 'results';
+
+  // Map pr_status → reason + human-readable status
+  const statusMap = {
+    will_create:          { reason: 'new_changes',  human: 'New PR would be created on stable branch' },
+    will_update_existing: { reason: 'new_changes',  human: 'Existing PR would be updated (force-push)' },
+    will_close_stale:     { reason: 'in_sync',      human: 'Stale PR would be closed (repo in sync)' },
+    no_change:            { reason: 'in_sync',      human: 'No changes needed' },
+    aborted:              { reason: 'non_bot_commits_on_branch', human: 'Aborted — non-bot commits on stable branch' },
+  };
+
+  const record = {
+    repo,
+    ...campaignData,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (errorOccurred) {
+    record.error = true;
+    record.error_message = errorMessage;
+    record.error_step = errorStep;
+    record.status = 'error';
+  } else {
+    const mapping = statusMap[prStatus] || { reason: prStatus, human: prStatus };
+    record.pr_status = prStatus;
+    record.reason = mapping.reason;
+    record.pr_would_be_created = prStatus === 'will_create';
+    record.pr_would_be_updated = prStatus === 'will_update_existing';
+    record.pr_would_be_closed = prStatus === 'will_close_stale';
+    record.aborted = prStatus === 'aborted';
+
+    if (prNumber) record.pr_number = parseInt(prNumber, 10);
+    if (prUrl) record.pr_url = prUrl;
+    if (nonBotShas) record.non_bot_shas = nonBotShas.split(/\s+/).filter(Boolean);
+  }
+
+  const jsonlLine = JSON.stringify(record) + '\n';
+  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, `${outputName}.jsonl`), jsonlLine);
+
+  // Markdown summary
+  const lines = [`### ${repo}`];
+  if (errorOccurred) {
+    lines.push(`- ERROR: ${errorMessage}`);
+    lines.push(`- Failed at step: ${errorStep}`);
+    lines.push(`- Status: Skipped`);
+  } else {
+    const mapping = statusMap[prStatus] || { reason: prStatus, human: prStatus };
+    const verb = mode === 'plan' ? 'WOULD' : 'DID';
+    lines.push(`- ${verb} ${mapping.human}`);
+    if (prUrl) lines.push(`- PR URL: ${prUrl}`);
+    if (prStatus === 'aborted' && nonBotShas) {
+      lines.push(`- Non-bot SHAs on branch: ${nonBotShas}`);
+    }
+  }
+
+  for (const [key, value] of Object.entries(campaignData)) {
+    lines.push(`- ${key}: ${value !== null && value !== undefined ? value : 'N/A'}`);
+  }
+
+  const md = lines.join('\n') + '\n';
+  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, `${outputName}.md`), md);
+
+  console.log(`Recorded outcome to ${outputName}.jsonl and ${outputName}.md`);
+} catch (err) {
+  console.error(`::error::${err.message}`);
+  process.exit(1);
+}

--- a/campaigns/release-automation-onboarding/templates/pr-body-update.mustache
+++ b/campaigns/release-automation-onboarding/templates/pr-body-update.mustache
@@ -1,0 +1,45 @@
+## Update release-automation + validation callers for {{name}}
+
+**TL;DR:** This PR updates the **release automation** and **CAMARA Validation** workflows in **{{name}}** to the latest version from [`camaraproject/tooling`](https://github.com/camaraproject/tooling) (`@{{caller_ref}}` / `@{{validation_ref}}`).
+
+### Reminder: what release automation does
+
+The release automation workflow enables slash commands on **Release Issues** to manage your release lifecycle. Post these as comments on the Release Issue:
+- `/create-snapshot` — create a snapshot branch (updates versions, changelog entries, and release metadata automatically)
+- `/discard-snapshot <reason>` — discard a snapshot and return to planned state
+- `/delete-draft` — delete a draft release
+- `/publish-release --confirm rX.Y` — publish the release
+
+### Refs applied
+
+| Caller | Pinned to |
+|--------|-----------|
+| `.github/workflows/release-automation.yml` | `@{{caller_ref}}` |
+| `.github/workflows/camara-validation.yml` | `@{{validation_ref}}` |
+
+### Changes
+
+```
+{{change_stat}}
+```
+
+See the PR's Files changed tab for the full diff.
+{{#has_warnings}}
+
+### Warnings
+
+{{warnings}}
+{{/has_warnings}}
+
+### What to do next
+
+1. **Review** the changes above
+2. **Merge** this PR
+3. **Trigger the workflow manually once** to make sure all changes are applied:
+   - Go to **Actions → [Release Automation](https://github.com/{{org}}/{{name}}/actions/workflows/release-automation.yml) → Run workflow**
+
+### Documentation
+
+:book: [Release Management Documentation](https://github.com/camaraproject/ReleaseManagement/tree/main/documentation)
+:book: [Release Lifecycle](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/release-process/lifecycle.md)
+:book: [The release-plan.yaml File](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/metadata/release-plan.md)


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds a reconciliation mode to the release-automation onboarding campaign so we can push ongoing caller-template updates to already-onboarded repos without creating a fresh PR on every dispatch. First use case is the `code/common/**` push-trigger addition that landed on `validation-framework`; longer term this is the vehicle for any caller-template change (ref bumps from `@v1-rc` to `@v1` on GA, additional trigger paths, etc.).

##### New: `actions/campaign-reconcile-per-repo/`

Sibling to `actions/campaign-finalize-per-repo/`. Keeps the existing action untouched (still used by `campaign-release-info.yml` and `campaign-release-plan-rollout.yml`).

Reconciliation behaviour:

| Repo state | Open PR on stable branch? | Action |
|--|--|--|
| In sync with template | no  | No-op |
| In sync with template | yes | Close PR with comment ("repo in sync") |
| Drift vs main | no  | Push fresh branch + open PR |
| Drift vs main | yes, bot-authored HEAD | Rebuild branch from main + template, `git push --force-with-lease` — PR updates |
| Drift vs main | yes, non-bot commits on branch | Abort with SHAs; operator merges or closes the PR first |

Stable branch + stable PR title (caller-provided inputs). Force-push safety via `--force-with-lease` plus an author-email guard against non-bot commits (default pattern: `^[0-9]+\+.*\[bot\]@users\.noreply\.github\.com$`, overridable).

##### Changes in `campaign-release-automation-onboarding.yml`

- Renamed (header + workflow `name`) from "Onboarding" to "Reconciliation" to reflect the scope.
- New `mode_state` step classifies each run as **initial onboarding** (no `.github/workflows/release-automation.yml` on the repo's main) vs **caller update**, and picks the matching PR title + body template accordingly:
  - Initial: `[bulk] Enable release automation and validation` → `pr-body.mustache` (unchanged from today)
  - Update: `[bulk] Update release-automation + validation callers` → new `pr-body-update.mustache`
- New `change_summary` step (runs only on the update variant) captures `git diff --cached --stat` for the PR body.
- Stable branch `camara/release-automation-update` (reusable for future caller updates).
- Swaps `campaign-finalize-per-repo` → `campaign-reconcile-per-repo`.
- Removes the now-redundant "Detect changes" step (the reconcile action owns detection).

##### New: `campaigns/release-automation-onboarding/templates/pr-body-update.mustache`

Dedicated PR body for the caller-update variant: short intro, refs applied table, dynamic `{{change_stat}}`, retains the slash-command reminder, finishes with a manual-dispatch instruction.

#### Which issue(s) this PR fixes:

n/a — supports camaraproject/ReleaseManagement#484 (stage flip & pilot feedback for r4.2).

#### Special notes for reviewers:

- `actions/campaign-finalize-per-repo/` is deliberately untouched. Its two remaining callers (`campaign-release-info.yml`, `campaign-release-plan-rollout.yml`) keep their current run-id-branch / date-stamped-title semantics. When those campaigns retire, the two actions can consolidate.
- `--force-with-lease` + non-bot-commit guard: if a codeowner force-pushes or adds manual commits to `camara/release-automation-update`, the next campaign run aborts with a clear message rather than overwriting. Operator cleanup is to merge or close the PR.
- First post-merge end-to-end test: dispatch in `plan` mode to verify the action mints an App token (exercises the recently-merged client-id migration) and inspect the plan artifact. Then a canary `apply` on `ReleaseTest` before a batch rollout.

#### Changelog input

```
 release-note
 none
```

#### Additional documentation

`actions/campaign-reconcile-per-repo/README.md` documents inputs, behaviour, and the comparison with the sibling action.

```
docs
none
```