### PR TITLE
fix(reconcile): pass bot-email regex via ENVIRON, not awk -v

### DIFF
--- a/actions/campaign-reconcile-per-repo/action.yml
+++ b/actions/campaign-reconcile-per-repo/action.yml
@@ -123,8 +123,14 @@ runs:
       if: ${{ inputs.error_occurred != 'true' && steps.detect.outputs.pr_exists == 'true' }}
       shell: bash
       working-directory: repo
+      env:
+        # Passing the regex via ENVIRON[] (instead of awk -v) preserves backslash
+        # escapes intact. awk's -v option applies its own escape-processing pass,
+        # which silently corrupts patterns like `\+`, `\[`, `\.` — making the
+        # non-bot guard match nothing (or flag every commit, depending on the
+        # regex). ENVIRON[] hands awk the literal string.
+        BOT_EMAIL_PATTERN: ${{ inputs.bot_email_pattern }}
       run: |
-        PATTERN='${{ inputs.bot_email_pattern }}'
         # Fetch just the branch tip + its path back to main
         git fetch origin "${{ inputs.branch }}" || true
         MERGE_BASE=$(git merge-base "origin/${{ inputs.branch }}" "origin/main" 2>/dev/null || true)
@@ -136,7 +142,7 @@ runs:
         fi
 
         NON_BOT_SHAS=$(git log --format='%H|%ae' "$MERGE_BASE..origin/${{ inputs.branch }}" \
-          | awk -F'|' -v pat="$PATTERN" '$2 !~ pat { print $1 }' \
+          | awk -F'|' 'BEGIN{pat=ENVIRON["BOT_EMAIL_PATTERN"]} $2 !~ pat { print $1 }' \
           | tr '\n' ' ')
 
         if [ -n "${NON_BOT_SHAS// /}" ]; then


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

The non-bot-commit guard in `actions/campaign-reconcile-per-repo/action.yml` passed the email regex to awk via `-v pat="$PATTERN"`. awk's `-v` applies a second pass of backslash processing, which stripped the escapes out of the default regex `^[0-9]+\+.*\[bot\]@users\.noreply\.github\.com$`. By the time awk saw the pattern, `\+` had become a stray ERE quantifier and `\[bot\]` had become a character class — so the matcher treated every commit author (including the legitimate bot noreply email `<id>+<slug>[bot]@users.noreply.github.com`) as non-bot, and every rerun aborted.

Fix: drop `-v`, pass the pattern via a step-level env var and read it inside awk with `ENVIRON["BOT_EMAIL_PATTERN"]`. awk treats ENVIRON values as literal strings — no extra escape pass.

#### Which issue(s) this PR fixes:

n/a — follow-up to camaraproject/project-administration#211.

#### Special notes for reviewers:

Observed on camaraproject/ReleaseTest PR #87 (open, bot-authored) — a rerun of the reconciliation campaign aborted flagging the bot's own commit. With this fix, the same input is correctly classified as bot-authored and the rerun proceeds to the force-push path without creating a second PR.

#### Changelog input

```
 release-note
 none
```

#### Additional documentation

n/a

```
docs
none
```