### PR TITLE
fix(reconcile): skip force-push when rebuilt tree matches PR branch

### DIFF
--- a/actions/campaign-reconcile-per-repo/README.md
+++ b/actions/campaign-reconcile-per-repo/README.md
@@ -17,7 +17,8 @@ takes it from there.
 | In sync (no diff vs main) | no  | No-op. |
 | In sync (no diff vs main) | yes | Close the PR with a comment — repo is now in sync. |
 | Drift vs main | no  | Push a fresh branch built from main + template, open PR with stable title. |
-| Drift vs main | yes, branch HEAD is bot-authored | Rebuild branch from main + template, `git push --force-with-lease`. Existing PR updates automatically; no second PR. |
+| Drift vs main | yes, bot-authored, rebuild tree matches PR branch tip | No-op push (tree equality check) — existing PR left untouched, codeowner approvals preserved. |
+| Drift vs main | yes, bot-authored, rebuild tree differs from PR branch tip | Rebuild branch from main + template, `git push --force-with-lease`. Existing PR updates automatically; no second PR. |
 | Drift vs main | yes, branch HEAD has **non-bot** commits | Abort. Operator merges or closes the PR first. Next run either reconciles cleanly (if merged to main) or waits for the branch to be reclaimed. |
 
 The stable **branch name** and **PR title** are inputs — reusable for any
@@ -71,8 +72,9 @@ See `action.yml` for the full schema. Key fields:
 
 Each per-repo run records a JSONL row with:
 
-- `pr_status`: `will_create` | `will_update_existing` | `will_close_stale` | `no_change` | `aborted`
-- `reason`: `new_changes` | `in_sync` | `non_bot_commits_on_branch` | `error`
+- `pr_status`: `will_create` | `will_update_existing` | `no_change_vs_existing_pr` | `will_close_stale` | `no_change` | `aborted`
+- `reason`: `new_changes` | `in_sync_with_existing_pr` | `in_sync` | `non_bot_commits_on_branch` | `error`
+- `tree_match`: `true` when the rebuilt tree matches the existing PR branch tip (push was skipped)
 - `pr_number`, `pr_url` (if applicable)
 - `non_bot_shas` (only on abort)
 - Any campaign-specific fields threaded through `campaign_data`

--- a/actions/campaign-reconcile-per-repo/action.yml
+++ b/actions/campaign-reconcile-per-repo/action.yml
@@ -272,20 +272,45 @@ runs:
         if git diff --cached --quiet; then
           echo "Nothing to commit after rebuilding branch from main — skipping push."
           echo "pushed=false" >> $GITHUB_OUTPUT
+          echo "tree_match=false" >> $GITHUB_OUTPUT
           exit 0
         fi
 
         git commit -m "${{ inputs.pr_title }}"
 
+        # Avoid churning an existing PR's head SHA (and thus dismissing codeowner
+        # approvals) when the rebuilt content matches what's already on the
+        # remote branch. Tree equality is the right check: same tree means same
+        # content even though the commit SHA differs (author timestamp changes).
+        BRANCH_EXISTS=false
+        TREE_MATCH=false
+        if git ls-remote --exit-code --heads origin "${{ inputs.branch }}" >/dev/null 2>&1; then
+          BRANCH_EXISTS=true
+          git fetch origin "${{ inputs.branch }}"
+          LOCAL_TREE=$(git rev-parse "HEAD^{tree}")
+          REMOTE_TREE=$(git rev-parse "origin/${{ inputs.branch }}^{tree}")
+          if [ "$LOCAL_TREE" = "$REMOTE_TREE" ]; then
+            TREE_MATCH=true
+          fi
+        fi
+
+        if [ "$TREE_MATCH" = "true" ]; then
+          echo "Remote branch already has this tree ($LOCAL_TREE) — skipping push to preserve existing PR approvals."
+          echo "pushed=false" >> $GITHUB_OUTPUT
+          echo "tree_match=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Use --force-with-lease to abort on concurrent remote changes.
         # If the branch doesn't exist yet on origin, fall back to a regular push.
-        if git ls-remote --exit-code --heads origin "${{ inputs.branch }}" >/dev/null 2>&1; then
+        if [ "$BRANCH_EXISTS" = "true" ]; then
           git push --force-with-lease origin "${{ inputs.branch }}"
         else
           git push origin "${{ inputs.branch }}"
         fi
 
         echo "pushed=true" >> $GITHUB_OUTPUT
+        echo "tree_match=false" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
@@ -350,6 +375,7 @@ runs:
         INPUT_MODE: ${{ inputs.mode }}
         INPUT_CAMPAIGN_DATA: ${{ inputs.campaign_data }}
         INPUT_PR_STATUS: ${{ steps.pr_status.outputs.pr_status }}
+        INPUT_TREE_MATCH: ${{ steps.push.outputs.tree_match }}
         INPUT_PR_NUMBER: ${{ steps.detect.outputs.pr_number }}
         INPUT_PR_URL: ${{ steps.pr_create.outputs.created_pr_url || steps.detect.outputs.pr_url }}
         INPUT_NON_BOT_SHAS: ${{ steps.verify_authorship.outputs.non_bot_shas }}

--- a/actions/campaign-reconcile-per-repo/dist/index.js
+++ b/actions/campaign-reconcile-per-repo/dist/index.js
@@ -9,10 +9,11 @@ try {
   const repo = getInput('repo');
   const mode = getInput('mode');
   const campaignDataStr = getInput('campaign_data') || '{}';
-  const prStatus = getInput('pr_status');
+  let prStatus = getInput('pr_status');
   const prNumber = getInput('pr_number');
   const prUrl = getInput('pr_url');
   const nonBotShas = getInput('non_bot_shas').trim();
+  const treeMatch = getInput('tree_match') === 'true';
   const errorOccurred = getInput('error_occurred') === 'true';
   const errorMessage = getInput('error_message');
   const errorStep = getInput('error_step');
@@ -20,13 +21,21 @@ try {
   const campaignData = JSON.parse(campaignDataStr);
   const outputName = mode === 'plan' ? 'plan' : 'results';
 
+  // When we rebuild the branch and the resulting tree is identical to what's
+  // already on the remote branch, the force-push is skipped. Reflect that in
+  // the outcome so runs don't report "updated existing PR" when nothing moved.
+  if (prStatus === 'will_update_existing' && treeMatch) {
+    prStatus = 'no_change_vs_existing_pr';
+  }
+
   // Map pr_status → reason + human-readable status
   const statusMap = {
-    will_create:          { reason: 'new_changes',  human: 'New PR would be created on stable branch' },
-    will_update_existing: { reason: 'new_changes',  human: 'Existing PR would be updated (force-push)' },
-    will_close_stale:     { reason: 'in_sync',      human: 'Stale PR would be closed (repo in sync)' },
-    no_change:            { reason: 'in_sync',      human: 'No changes needed' },
-    aborted:              { reason: 'non_bot_commits_on_branch', human: 'Aborted — non-bot commits on stable branch' },
+    will_create:              { reason: 'new_changes',  human: 'New PR would be created on stable branch' },
+    will_update_existing:     { reason: 'new_changes',  human: 'Existing PR would be updated (force-push)' },
+    no_change_vs_existing_pr: { reason: 'in_sync_with_existing_pr', human: 'No change vs existing PR — push skipped to preserve approvals' },
+    will_close_stale:         { reason: 'in_sync',      human: 'Stale PR would be closed (repo in sync)' },
+    no_change:                { reason: 'in_sync',      human: 'No changes needed' },
+    aborted:                  { reason: 'non_bot_commits_on_branch', human: 'Aborted — non-bot commits on stable branch' },
   };
 
   const record = {
@@ -48,6 +57,7 @@ try {
     record.pr_would_be_updated = prStatus === 'will_update_existing';
     record.pr_would_be_closed = prStatus === 'will_close_stale';
     record.aborted = prStatus === 'aborted';
+    if (treeMatch) record.tree_match = true;
 
     if (prNumber) record.pr_number = parseInt(prNumber, 10);
     if (prUrl) record.pr_url = prUrl;


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Before this fix, every reconciliation rerun produced a new commit (same tree, fresh timestamp → fresh SHA) and force-pushed it to the stable branch. The content didn't change, but the PR head SHA did — which dismisses existing codeowner approvals under the standard `dismiss_stale_reviews_on_push` rule.

With multiple codeowners this becomes a race: codeowner A reviews → reconciliation fires → approval dismissed → codeowner A needs to re-approve → reconciliation fires again, etc.

Fix: after `git commit`, compare `HEAD^{tree}` to `origin/<branch>^{tree}`. If equal, skip the push entirely. New status `no_change_vs_existing_pr` surfaces in the artifact JSONL / markdown summary.

Observed on camaraproject/ReleaseTest PR #87 — first rerun after the non-bot-guard fix (#212) produced a new head SHA with an identical tree. With this fix, subsequent reruns leave the PR head untouched.

#### Which issue(s) this PR fixes:

n/a — follow-up to camaraproject/project-administration#211 and #212.

#### Special notes for reviewers:

- Path unchanged when the tree differs (still force-pushes with `--force-with-lease`).
- Path unchanged when no PR exists yet (first apply creates the PR as before).
- Preserves the `git diff --cached --quiet` early-exit for the "main already matches template" degenerate case.

#### Changelog input

```
 release-note
 none
```

#### Additional documentation

`actions/campaign-reconcile-per-repo/README.md` table updated to split "rebuild tree matches" vs "rebuild tree differs".

```
docs
none
```