### PR TITLE
chore: exclude archived repos from onboarding campaign

### DIFF
--- a/.github/workflows/campaign-release-automation-onboarding.yml
+++ b/.github/workflows/campaign-release-automation-onboarding.yml
@@ -98,11 +98,13 @@ jobs:
             const org = process.env.ORG;
             const include = (process.env.INCLUDE || '').split(',').map(s => s.trim()).filter(Boolean);
 
-            // List all repositories in the organization
+            // List all non-archived repositories in the organization
+            // (PRs cannot be created against archived repos — same filter as
+            // the sibling campaign-release-plan-rollout workflow)
             let repos;
             try {
               const result = execSync(
-                `gh api --paginate "orgs/${org}/repos" --jq '.[].name'`,
+                `gh api --paginate "orgs/${org}/repos" --jq '.[] | select(.archived == false) | .name'`,
                 { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
               );
               repos = result.trim().split('\n').filter(Boolean);
@@ -111,7 +113,7 @@ jobs:
               return;
             }
 
-            console.log(`Found ${repos.length} repositories in ${org}`);
+            console.log(`Found ${repos.length} non-archived repositories in ${org}`);
 
             // Apply include filter
             if (include.length) {


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Adds a `select(.archived == false)` filter to the org repo listing in the
`select` job of `campaign-release-automation-onboarding.yml`, matching the
existing behaviour of the sibling `campaign-release-plan-rollout.yml`.

Without the filter, archived repositories (e.g. `camaraproject/TestRepo`)
were included as PR targets and failed downstream when the campaign tried
to create branches/PRs against them.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

Single-line jq change in the `gh api orgs/{org}/repos` call. Filters at
fetch time so archived repos never enter the per-repo eligibility loop.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.

```
docs

```