### PR TITLE
fix(progress-tracker): em-dash Ongoing Release once tag appears in Last Published

### DIFF
--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -604,6 +604,19 @@ tr.historical-row:hover td {
 
       if (!tag) return '<span class="milestone-empty">&mdash;</span>';
 
+      // Published and the same tag is already shown in Last Published (per-row,
+      // honoring the API filter): swap to em-dash to avoid showing the same tag twice.
+      if (state === 'published') {
+        const lp = row.last_published;
+        if (lp && lp.release_tag === tag) {
+          const apiInLastPublished = !lp.apis || !row.api_name
+            || lp.apis.some(a => a.api_name === row.api_name);
+          if (apiInLastPublished) {
+            return '<span class="milestone-empty">&mdash;</span>';
+          }
+        }
+      }
+
       // Line 1: release tag (clickable for published state)
       let line1;
       if (state === 'published') {


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

When an Ongoing Release has been published and the same tag already
appears in **Last Published**, the row currently shows the tag in both
columns. This swaps the **Ongoing Release** cell to an em-dash in that
case.

The check is per-row and honors the Last Published API filter: the swap
only triggers when the row's API actually appears in
`last_published.apis`. While `releases-master.yaml` lags behind
publication, `last_published` either points at the prior tag or doesn't
list the API yet, so the cell keeps showing the tag — the published
release never briefly disappears from both columns at once.

Single-file change in the viewer template; no Python, schema, or data
changes.

#### Which issue(s) this PR fixes:

Fixes #216

#### Special notes for reviewers:

- Logic added inside `renderOngoingReleaseCell` in
  `workflows/release-progress-tracker/templates/progress-template.html`.
- The API-filter mirrors the existing filter in
  `renderLastPublishedCell` (lines 660–665), so both cells stay in sync
  about whether the API is present in the release.

#### Changelog input

```
 release-note
 Progress Tracker viewer: show em-dash in Ongoing Release when the same tag is shown in Last Published.
```

#### Additional documentation

This section can be blank.

```
docs

```
