### PR TITLE
Release Progress Tracker: Hard-fail on transient errors and rate limits

### DIFF
--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -52,6 +52,17 @@ from .warnings import generate_warnings
 
 logger = logging.getLogger(__name__)
 
+
+class CollectionAbortedError(Exception):
+    """Raised when collection cannot complete a full pass.
+
+    Triggered by rate-limit exhaustion mid-run or by unrecovered per-repo
+    failures. The collector preserves the existing releases-progress.yaml
+    on disk rather than overwriting it with partial data; the workflow
+    sees a non-zero exit and skips the downstream PR/deploy jobs.
+    """
+
+
 # Repositories that have been split into sub-APIs and will not receive new
 # release-plan.yaml entries. Historical releases remain visible in the table
 # because they flow through all_releases, not the filtered repositories list.
@@ -519,6 +530,8 @@ def collect_all(
 
     stats = CollectionStats(repos_scanned=len(repositories))
     entries: List[ProgressEntry] = []
+    rate_limit_aborted = False
+    failed_repos: List[str] = []
 
     for repo_data in repositories:
         repo_name = repo_data.get("repository", "")
@@ -546,10 +559,28 @@ def collect_all(
                     stats.repos_with_release_issue += 1
         except RateLimitError:
             logger.error("Rate limit exhausted, aborting collection")
+            rate_limit_aborted = True
             break
         except Exception as e:
             logger.warning("%s: collection failed: %s", repo_name, e)
+            failed_repos.append(repo_name)
             continue
+
+    # Abort before writing partial data: a corrupted releases-progress.yaml
+    # is worse than a workflow failure (PA#209, PA#224).
+    if rate_limit_aborted:
+        raise CollectionAbortedError(
+            f"Rate limit exhausted after {api.api_calls} calls; "
+            f"{len(entries)}/{len(repositories)} repos collected. "
+            "Existing releases-progress.yaml left untouched."
+        )
+    if failed_repos:
+        sample = ", ".join(failed_repos[:5])
+        more = "" if len(failed_repos) <= 5 else f" (and {len(failed_repos) - 5} more)"
+        raise CollectionAbortedError(
+            f"{len(failed_repos)} repos failed during collection: {sample}{more}. "
+            "Existing releases-progress.yaml left untouched."
+        )
 
     # Count active repos that have no release-plan.yaml AND no published/pre releases.
     # These are freshly-created repos not yet onboarded.
@@ -690,6 +721,9 @@ def main():
         print(f"Data changed: {result.data_changed}")
         print(f"::endgroup::")
 
+    except CollectionAbortedError as e:
+        logger.error("Collection aborted: %s", e)
+        sys.exit(1)
     except Exception as e:
         logger.error("Collection failed: %s", e)
         sys.exit(1)

--- a/workflows/release-progress-tracker/scripts/github_api.py
+++ b/workflows/release-progress-tracker/scripts/github_api.py
@@ -8,6 +8,7 @@ All methods return parsed data or None on 404.
 import base64
 import logging
 import os
+import time
 from typing import Dict, List, Optional
 
 import requests
@@ -15,6 +16,10 @@ import requests
 logger = logging.getLogger(__name__)
 
 ORG = "camaraproject"
+
+RETRY_STATUS_CODES = frozenset({502, 503, 504})
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = (1, 2, 4)
 
 
 class RateLimitError(Exception):
@@ -24,7 +29,7 @@ class RateLimitError(Exception):
 class GitHubAPI:
     """Thin REST client for GitHub API operations needed by the collector."""
 
-    def __init__(self, token: Optional[str] = None):
+    def __init__(self, token: Optional[str] = None, sleep=time.sleep):
         self.session = requests.Session()
         self.public_session = requests.Session()
         self.token = token or os.environ.get("GITHUB_TOKEN", "")
@@ -34,6 +39,8 @@ class GitHubAPI:
             session.headers["Accept"] = "application/vnd.github+json"
             session.headers["X-GitHub-Api-Version"] = "2022-11-28"
         self.api_calls = 0
+        # Injectable so tests can avoid real backoff sleeps.
+        self._sleep = sleep
 
     def _request(
         self,
@@ -43,23 +50,68 @@ class GitHubAPI:
         public: bool = False,
         **kwargs,
     ) -> Optional[requests.Response]:
-        """Make an API request with rate limit monitoring."""
+        """Make an API request with rate-limit monitoring and transient retry.
+
+        Retries up to RETRY_ATTEMPTS times on HTTP 502/503/504 and on
+        connection / timeout errors with exponential backoff (1s, 2s, 4s).
+        404 and other 4xx responses are returned to the caller without
+        retry. Rate-limit exhaustion raises RateLimitError immediately.
+        """
         session = self.public_session if public or not self.token else self.session
-        resp = session.request(method, url, **kwargs)
-        self.api_calls += 1
 
-        # Monitor rate limit
-        remaining = resp.headers.get("X-RateLimit-Remaining")
-        if remaining is not None:
-            remaining = int(remaining)
-            if remaining == 0:
-                raise RateLimitError(
-                    f"GitHub API rate limit exhausted after {self.api_calls} calls"
+        for attempt in range(RETRY_ATTEMPTS + 1):
+            try:
+                resp = session.request(method, url, **kwargs)
+            except (requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout) as exc:
+                if attempt < RETRY_ATTEMPTS:
+                    delay = RETRY_BACKOFF_SECONDS[attempt]
+                    logger.warning(
+                        "Request to %s failed (%s); retrying in %ds (attempt %d/%d)",
+                        url, exc.__class__.__name__, delay,
+                        attempt + 1, RETRY_ATTEMPTS,
+                    )
+                    self._sleep(delay)
+                    continue
+                logger.error(
+                    "Request to %s failed after %d attempts: %s",
+                    url, RETRY_ATTEMPTS, exc,
                 )
-            if remaining < 50:
-                logger.warning("GitHub API rate limit low: %d remaining", remaining)
+                raise
 
-        return resp
+            self.api_calls += 1
+
+            # Rate-limit check first: an exhausted budget should abort
+            # collection regardless of status code on this response.
+            remaining = resp.headers.get("X-RateLimit-Remaining")
+            if remaining is not None:
+                remaining_int = int(remaining)
+                if remaining_int == 0:
+                    raise RateLimitError(
+                        f"GitHub API rate limit exhausted after {self.api_calls} calls"
+                    )
+                if remaining_int < 50:
+                    logger.warning("GitHub API rate limit low: %d remaining", remaining_int)
+
+            if resp.status_code in RETRY_STATUS_CODES and attempt < RETRY_ATTEMPTS:
+                delay = RETRY_BACKOFF_SECONDS[attempt]
+                logger.warning(
+                    "Request to %s returned %d; retrying in %ds (attempt %d/%d)",
+                    url, resp.status_code, delay,
+                    attempt + 1, RETRY_ATTEMPTS,
+                )
+                self._sleep(delay)
+                continue
+
+            if resp.status_code in RETRY_STATUS_CODES:
+                logger.error(
+                    "Request to %s returned %d after %d attempts",
+                    url, resp.status_code, RETRY_ATTEMPTS,
+                )
+
+            return resp
+
+        raise RuntimeError(f"Request to {url} exhausted retries unexpectedly")
 
     def _get(self, path: str, public: bool = False, **kwargs) -> Optional[requests.Response]:
         """GET request to GitHub API."""

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -455,8 +455,14 @@ class TestCollectAll:
         assert meta["repos_fully_onboarded"] == 0  # No caller workflow or active state
         assert meta["repos_with_release_issue"] == 0  # No release issues mocked
 
-    def test_collection_handles_api_errors(self, tmp_path):
-        """Repos with API errors should be skipped gracefully."""
+    def test_collection_aborts_on_per_repo_error(self, tmp_path):
+        """Per-repo failures abort the collection rather than silently dropping rows.
+
+        The existing output file must be preserved so the workflow does not
+        deploy partial data (PA#209).
+        """
+        from scripts.collect_progress import CollectionAbortedError
+
         master_data = {
             "metadata": SAMPLE_MASTER["metadata"],
             "repositories": [
@@ -474,11 +480,45 @@ class TestCollectAll:
                 raise ConnectionError("Network error")
 
         api = ErrorAPI()
-        result = collect_all(str(master_file), str(output_file), api=api)
+        with pytest.raises(CollectionAbortedError, match="ErrorRepo"):
+            collect_all(str(master_file), str(output_file), api=api)
 
-        assert result.collection_stats.repos_scanned == 1
-        assert result.collection_stats.repos_with_plan == 0
-        assert len(result.progress) == 0
+        assert not output_file.exists()
+
+    def test_collection_aborts_on_rate_limit(self, tmp_path):
+        """RateLimitError mid-loop aborts collection (PA#224).
+
+        The corrupted-PR symptom from ReleaseManagement#507 was caused by
+        the collector continuing to historical-fallback after a rate-limit
+        abort. The new contract is: raise CollectionAbortedError, leave
+        the existing releases-progress.yaml in place.
+        """
+        from scripts.collect_progress import CollectionAbortedError
+        from scripts.github_api import RateLimitError
+
+        master_data = {
+            "metadata": SAMPLE_MASTER["metadata"],
+            "repositories": [
+                {"repository": "RepoA",
+                 "github_url": "https://github.com/camaraproject/RepoA"},
+                {"repository": "RepoB",
+                 "github_url": "https://github.com/camaraproject/RepoB"},
+            ],
+            "releases": [],
+        }
+        master_file = tmp_path / "releases-master.yaml"
+        output_file = tmp_path / "releases-progress.yaml"
+        master_file.write_text(yaml.dump(master_data))
+
+        class RateLimitedAPI(MockGitHubAPI):
+            def get_file_content(self, repo, path, ref="main"):
+                raise RateLimitError("budget exhausted")
+
+        api = RateLimitedAPI()
+        with pytest.raises(CollectionAbortedError, match="Rate limit exhausted"):
+            collect_all(str(master_file), str(output_file), api=api)
+
+        assert not output_file.exists()
 
     def test_releases_master_updated_populated(self, tmp_path):
         """releases_master_updated should be read from master file metadata."""

--- a/workflows/release-progress-tracker/tests/test_github_api.py
+++ b/workflows/release-progress-tracker/tests/test_github_api.py
@@ -1,13 +1,16 @@
 """Tests for GitHub API client fallback behavior."""
 
-from scripts.github_api import GitHubAPI
+import pytest
+import requests
+
+from scripts.github_api import GitHubAPI, RateLimitError, RETRY_ATTEMPTS
 
 
 class FakeResponse:
-    def __init__(self, status_code, payload):
+    def __init__(self, status_code, payload, rate_limit_remaining="100"):
         self.status_code = status_code
         self._payload = payload
-        self.headers = {"X-RateLimit-Remaining": "100"}
+        self.headers = {"X-RateLimit-Remaining": rate_limit_remaining}
 
     def json(self):
         return self._payload
@@ -15,6 +18,33 @@ class FakeResponse:
     def raise_for_status(self):
         if self.status_code >= 400:
             raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class ScriptedSession:
+    """Stand-in for requests.Session that replays a scripted sequence.
+
+    Each entry is either a FakeResponse to return or an Exception to raise.
+    """
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls = 0
+
+    def request(self, method, url, **kwargs):
+        self.calls += 1
+        if not self._script:
+            raise AssertionError(f"unexpected request: {method} {url}")
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _api_with_session(script):
+    api = GitHubAPI(token="test-token", sleep=lambda _s: None)
+    api.session = ScriptedSession(script)
+    api.public_session = api.session
+    return api
 
 
 def test_find_release_issue_retries_public_when_auth_returns_empty(monkeypatch):
@@ -51,3 +81,66 @@ def test_find_release_issue_retries_public_when_auth_returns_empty(monkeypatch):
         ),
         "labels": ["release-issue"],
     }
+
+
+# Retry behavior on transient errors (PA#209) -----------------------------------
+
+
+@pytest.mark.parametrize("status", [502, 503, 504])
+def test_request_retries_on_transient_status_then_succeeds(status):
+    api = _api_with_session([
+        FakeResponse(status, None),
+        FakeResponse(200, {"ok": True}),
+    ])
+    resp = api._get("/some/path")
+    assert resp.status_code == 200
+    assert api.api_calls == 2
+
+
+def test_request_retries_until_exhaustion_then_returns_last_response():
+    api = _api_with_session([FakeResponse(503, None) for _ in range(RETRY_ATTEMPTS + 1)])
+    resp = api._get("/some/path")
+    assert resp.status_code == 503
+    assert api.api_calls == RETRY_ATTEMPTS + 1
+
+
+def test_request_no_retry_on_404():
+    api = _api_with_session([FakeResponse(404, None)])
+    resp = api._get("/missing")
+    assert resp.status_code == 404
+    assert api.api_calls == 1
+
+
+def test_request_no_retry_on_2xx():
+    api = _api_with_session([FakeResponse(200, {"ok": True})])
+    resp = api._get("/ok")
+    assert resp.status_code == 200
+    assert api.api_calls == 1
+
+
+def test_request_retries_on_connection_error():
+    api = _api_with_session([
+        requests.exceptions.ConnectionError("boom"),
+        FakeResponse(200, {"ok": True}),
+    ])
+    resp = api._get("/some/path")
+    assert resp.status_code == 200
+
+
+def test_request_raises_after_repeated_connection_errors():
+    api = _api_with_session([
+        requests.exceptions.ConnectionError("boom")
+        for _ in range(RETRY_ATTEMPTS + 1)
+    ])
+    with pytest.raises(requests.exceptions.ConnectionError):
+        api._get("/some/path")
+
+
+def test_request_raises_rate_limit_immediately_no_retry():
+    """Rate-limit exhaustion is non-recoverable — no point retrying."""
+    api = _api_with_session([
+        FakeResponse(200, None, rate_limit_remaining="0"),
+    ])
+    with pytest.raises(RateLimitError):
+        api._get("/some/path")
+    assert api.api_calls == 1


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Makes the Release Progress Tracker collector fail loudly instead of
silently producing a partial `releases-progress.yaml`:

- `github_api._request` retries HTTP 502/503/504 + `ConnectionError` /
  `Timeout` with exponential backoff (1s/2s/4s, up to 3 retries).
  `RateLimitError` still raises immediately.
- `collect_progress.collect_all` raises a new `CollectionAbortedError`
  on rate-limit abort or per-repo failures, before writing output.
  Existing `releases-progress.yaml` is preserved; `main()` exits 1.

Downstream workflow jobs already gate on collect-step success, so no
`release-progress-tracker.yml` change is needed.

#### Which issue(s) this PR fixes:

Fixes #209
Fixes #224

#### Special notes for reviewers:

`python3 -m pytest workflows/release-progress-tracker/tests/ -q` →
151 passed (10 new). The prior `test_collection_handles_api_errors`
was rewritten — it had been asserting the silent-drop behavior #209
reports as a bug.

#### Changelog input

```
 release-note
Release Progress Tracker: collector retries transient GitHub API errors
and aborts (preserving existing data) on exhaustion or rate-limit hit.
```

#### Additional documentation

```
docs
```
