### PR TITLE
State-badge tooltips and drop COMPLETED state

### DIFF
--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -172,17 +172,15 @@ properties:
             - snapshot_active
             - draft_ready
             - published
-            - completed
             - historical
           description: |
             Derived from repository artifacts:
-            - not_planned: target_release_type is none, plan does not match last public release
-            - planned: Has plan, no release artifacts
-            - snapshot_active: Snapshot branch exists
-            - draft_ready: Snapshot branch + draft release exist
-            - published: Release tag exists
-            - completed: target_release_type is none, plan exactly matches last public release
-            - historical: No release-plan.yaml; entry derived from releases-master.yaml only
+            - not_planned: target_release_type is none — no active release planned
+            - planned: Release planned, no release artifacts yet
+            - snapshot_active: Release-snapshot branch exists; review in progress
+            - draft_ready: Snapshot branch + draft release ready for publication
+            - published: Release tag published
+            - historical: No active release-plan.yaml; entry derived from releases-master.yaml only
 
         source:
           type: string

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -109,47 +109,6 @@ def _tag_prefix(release_tag: str) -> str:
     return release_tag[:dot_index + 1] if dot_index != -1 else release_tag + "."
 
 
-def _check_completed_state(entry: ProgressEntry, all_releases: List[Dict]) -> ProgressState:
-    """Upgrade NOT_PLANNED to COMPLETED when release-plan exactly matches a completed release.
-
-    Conditions (all must hold):
-    1. target_release_tag exactly matches a public-release or maintenance-release
-       for this repo in releases-master.yaml (a maintenance-release implies a prior
-       public-release in the same cycle, so both count as completed states).
-    2. Every planned API's target_api_version matches the api_version in that release.
-    3. entry.apis is non-empty (empty API list is not verifiable, stays NOT_PLANNED).
-    """
-    if not entry.target_release_tag or not entry.apis:
-        return ProgressState.NOT_PLANNED
-
-    _TERMINAL_TYPES = {"public-release", "maintenance-release"}
-
-    matched_release = next(
-        (
-            r for r in all_releases
-            if r.get("repository") == entry.repository
-            and r.get("release_tag") == entry.target_release_tag
-            and r.get("release_type") in _TERMINAL_TYPES
-        ),
-        None,
-    )
-
-    if not matched_release:
-        return ProgressState.NOT_PLANNED
-
-    release_api_versions = {
-        a.get("api_name"): a.get("api_version")
-        for a in matched_release.get("apis", [])
-        if a.get("api_name")
-    }
-
-    for api_entry in entry.apis:
-        if release_api_versions.get(api_entry.api_name) != api_entry.target_api_version:
-            return ProgressState.NOT_PLANNED
-
-    return ProgressState.COMPLETED
-
-
 # meta_release values that indicate an independent / non-meta-release repo
 # Includes legacy "None (Sandbox)" for backward compatibility with old releases-master.yaml data
 _INDEPENDENT_META_RELEASES = {"Independent", "None (Sandbox)", "None"}
@@ -333,8 +292,6 @@ def collect_repo_progress(
         entry.last_published = derive_last_published(
             repo_name, target_tag, all_releases,
         )
-        # Upgrade to COMPLETED if plan exactly matches last public release
-        entry.state = _check_completed_state(entry, all_releases)
         # Generate warnings
         repo_releases = [r for r in all_releases if r.get("repository") == repo_name]
         entry.warnings = generate_warnings(entry, repo_releases)

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -20,7 +20,6 @@ class ProgressState(Enum):
     SNAPSHOT_ACTIVE = "snapshot_active"
     DRAFT_READY = "draft_ready"
     PUBLISHED = "published"
-    COMPLETED = "completed"    # target_release_type=none, plan exactly matches last public release
     HISTORICAL = "historical"  # No release-plan.yaml; derived from releases-master.yaml only
 
 

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -19,14 +19,52 @@
   white-space: nowrap;
   color: #ffffff;
   letter-spacing: 0.3px;
+  position: relative;
+  cursor: help;
 }
 
 .state-not_planned { background: #C2C9D1; color: #24292f; }
-.state-completed   { background: #E8EBEE; color: #57606a; }
 .state-planned { background: #0969da; }
 .state-snapshot_active { background: #FBCA04; color: #24292f; }
 .state-draft_ready { background: #1D76DB; }
 .state-published { background: #0E8A16; }
+
+/* State badge tooltip — mirrors .warning-tooltip pattern for instant CSS-driven hover */
+.state-badge .state-tooltip {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 4px;
+  background: #2c3e50;
+  color: #ffffff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: normal;
+  white-space: normal;
+  min-width: 200px;
+  max-width: 320px;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  line-height: 1.4;
+  text-align: left;
+  letter-spacing: normal;
+  pointer-events: none;
+}
+
+.state-badge:hover .state-tooltip {
+  display: block;
+}
+
+/* Flip top-row state tooltips below the badge so they stay clear of sticky headers */
+.tooltip-below-row .state-badge .state-tooltip {
+  bottom: auto;
+  top: 100%;
+  margin-top: 4px;
+  margin-bottom: 0;
+}
 
 /* State artifact link below badge */
 .state-artifact {
@@ -133,17 +171,11 @@ a.milestone-tag:hover {
   line-height: 1.3;
 }
 
-/* NOT_PLANNED / COMPLETED / HISTORICAL row dimming */
+/* NOT_PLANNED / HISTORICAL row dimming */
 tr.not-planned-row td {
   opacity: 0.6;
 }
 tr.not-planned-row:hover td {
-  opacity: 1;
-}
-tr.completed-row td {
-  opacity: 0.8;
-}
-tr.completed-row:hover td {
   opacity: 1;
 }
 tr.historical-row td {
@@ -255,8 +287,7 @@ tr.historical-row:hover td {
               <option value="draft_ready">Draft Ready</option>
               <option value="snapshot_active">Snapshot</option>
               <option value="planned">Planned</option>
-              <option value="completed">Completed</option>
-              <option value="not_planned">None</option>
+              <option value="not_planned">Not Planned</option>
               <option value="historical">Historical</option>
             </select>
           </div>
@@ -326,9 +357,19 @@ tr.historical-row:hover td {
       'draft_ready':     { label: 'Draft Ready', color: '#1D76DB', order: 2 },
       'snapshot_active': { label: 'Snapshot',    color: '#FBCA04', order: 3 },
       'planned':         { label: 'Planned',     color: '#0969da', order: 4 },
-      'completed':       { label: 'Completed',   color: '#E8EBEE', order: 5 },
-      'not_planned':     { label: 'None',        color: '#C2C9D1', order: 6 },
-      'historical':      { label: null,          color: null,      order: 7 },
+      'not_planned':     { label: '—',           color: '#C2C9D1', order: 5 },
+      'historical':      { label: null,          color: null,      order: 6 },
+    };
+
+    // Tooltip text shown on hover for each state badge. Keys must match
+    // STATE_CONFIG and the schema enum in releases-progress-schema.yaml.
+    const STATE_TOOLTIPS = {
+      'published':       'Published: release tag exists',
+      'draft_ready':     'Draft Ready: snapshot branch and draft release exist',
+      'snapshot_active': 'Snapshot: release-snapshot branch exists; review in progress',
+      'planned':         'Planned: release planned, no release artifacts yet',
+      'not_planned':     'Not Planned: target_release_type is none — no active release planned',
+      'historical':      'Historical: no active release-plan.yaml; entry derived from releases-master.yaml',
     };
 
     const COL_COUNT = 9;
@@ -562,7 +603,11 @@ tr.historical-row:hover td {
 
       // Historical entries carry no state badge
       if (cfg.label !== null) {
-        html = `<span class="state-badge state-${row.state}">${cfg.label}</span>`;
+        const tooltip = STATE_TOOLTIPS[row.state] || '';
+        const tooltipHtml = tooltip
+          ? `<span class="state-tooltip">${ViewerLib.escapeHtml(tooltip)}</span>`
+          : '';
+        html = `<span class="state-badge state-${row.state}">${cfg.label}${tooltipHtml}</span>`;
       }
 
       if (row.warnings && row.warnings.length > 0) {
@@ -583,12 +628,12 @@ tr.historical-row:hover td {
       const tag = row.target_release_tag;
       const artifacts = row.artifacts || {};
 
-      // Completed and historical: no ongoing release target
-      if (state === 'completed' || state === 'historical') {
+      // Historical: no ongoing release target
+      if (state === 'historical') {
         return '<span class="milestone-empty">&mdash;</span>';
       }
 
-      // Not Planned (None): show plan data only if it differs from last published
+      // Not Planned: show plan data only if it differs from last published
       if (state === 'not_planned') {
         const lp = row.last_published;
         const hasDifferentPlan = tag && (!lp || lp.release_tag !== tag);
@@ -751,8 +796,6 @@ tr.historical-row:hover td {
 
       if (row.state === 'not_planned') {
         tr.className = 'not-planned-row';
-      } else if (row.state === 'completed') {
-        tr.className = 'completed-row';
       } else if (row.state === 'historical') {
         tr.className = 'historical-row';
       }

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 
 from scripts.collect_progress import (
-    _check_completed_state,
     build_published_context_map,
     collect_all,
     collect_historical_entries,
@@ -631,7 +630,7 @@ class TestCollectAllWithExisting:
         assert result.data_changed is True
 
 
-# Fixtures for COMPLETED / HISTORICAL tests
+# Fixtures for HISTORICAL tests
 
 PUBLIC_RELEASE = {
     "repository": "QualityOnDemand",
@@ -643,7 +642,7 @@ PUBLIC_RELEASE = {
     "apis": [{"api_name": "quality-on-demand", "api_version": "1.0.0"}],
 }
 
-PLAN_COMPLETED = yaml.dump({
+PLAN_NONE_FALL25 = yaml.dump({
     "repository": {
         "release_track": "meta-release",
         "meta_release": "Fall25",
@@ -651,17 +650,6 @@ PLAN_COMPLETED = yaml.dump({
         "target_release_type": "none",
     },
     "apis": [{"api_name": "quality-on-demand", "target_api_version": "1.0.0",
-              "target_api_status": "stable"}],
-})
-
-PLAN_NONE_WITH_TAG = yaml.dump({
-    "repository": {
-        "release_track": "meta-release",
-        "meta_release": "Fall25",
-        "target_release_tag": "r3.2",
-        "target_release_type": "none",
-    },
-    "apis": [{"api_name": "quality-on-demand", "target_api_version": "0.9.0",
               "target_api_status": "stable"}],
 })
 
@@ -694,121 +682,6 @@ HISTORICAL_MASTER = {
         },
     ],
 }
-
-
-class TestCheckCompletedState:
-    def _make_entry(self, tag, apis, state=ProgressState.NOT_PLANNED):
-        return ProgressEntry(
-            repository="QualityOnDemand",
-            github_url="https://github.com/camaraproject/QualityOnDemand",
-            target_release_tag=tag,
-            target_release_type="none",
-            apis=apis,
-            state=state,
-        )
-
-    def test_exact_match_returns_completed(self):
-        entry = self._make_entry(
-            "r3.2",
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        result = _check_completed_state(entry, [PUBLIC_RELEASE])
-        assert result == ProgressState.COMPLETED
-
-    def test_version_mismatch_returns_not_planned(self):
-        entry = self._make_entry(
-            "r3.2",
-            [ApiEntry("quality-on-demand", "0.9.0", "stable")],
-        )
-        result = _check_completed_state(entry, [PUBLIC_RELEASE])
-        assert result == ProgressState.NOT_PLANNED
-
-    def test_tag_mismatch_returns_not_planned(self):
-        entry = self._make_entry(
-            "r3.1",  # different tag
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        result = _check_completed_state(entry, [PUBLIC_RELEASE])
-        assert result == ProgressState.NOT_PLANNED
-
-    def test_no_tag_returns_not_planned(self):
-        entry = self._make_entry(None, [ApiEntry("quality-on-demand", "1.0.0", "stable")])
-        result = _check_completed_state(entry, [PUBLIC_RELEASE])
-        assert result == ProgressState.NOT_PLANNED
-
-    def test_empty_apis_returns_not_planned(self):
-        entry = self._make_entry("r3.2", [])
-        result = _check_completed_state(entry, [PUBLIC_RELEASE])
-        assert result == ProgressState.NOT_PLANNED
-
-    def test_no_public_release_returns_not_planned(self):
-        pre_release = {**PUBLIC_RELEASE, "release_type": "pre-release-rc"}
-        entry = self._make_entry(
-            "r3.2",
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        result = _check_completed_state(entry, [pre_release])
-        assert result == ProgressState.NOT_PLANNED
-
-    def test_most_recent_public_release_used(self):
-        """When multiple public releases exist, any matching tag returns COMPLETED."""
-        older = {**PUBLIC_RELEASE, "release_tag": "r3.1",
-                 "release_date": "2025-10-01T00:00:00Z"}
-        entry = self._make_entry(
-            "r3.2",
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        # r3.2 (PUBLIC_RELEASE) matches exactly
-        result = _check_completed_state(entry, [older, PUBLIC_RELEASE])
-        assert result == ProgressState.COMPLETED
-
-    def test_maintenance_release_tag_returns_completed(self):
-        """Plan pointing to a maintenance-release tag also counts as COMPLETED."""
-        maintenance = {**PUBLIC_RELEASE, "release_tag": "r3.3",
-                       "release_date": "2025-12-01T00:00:00Z",
-                       "release_type": "maintenance-release"}
-        entry = self._make_entry(
-            "r3.3",
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        result = _check_completed_state(entry, [PUBLIC_RELEASE, maintenance])
-        assert result == ProgressState.COMPLETED
-
-    def test_pre_release_tag_not_accepted(self):
-        """Plan pointing to a pre-release tag is NOT counted as COMPLETED."""
-        pre_release = {**PUBLIC_RELEASE, "release_tag": "r3.1",
-                       "release_date": "2025-09-01T00:00:00Z",
-                       "release_type": "pre-release-rc"}
-        entry = self._make_entry(
-            "r3.1",
-            [ApiEntry("quality-on-demand", "1.0.0", "stable")],
-        )
-        result = _check_completed_state(entry, [pre_release])
-        assert result == ProgressState.NOT_PLANNED
-
-
-class TestCollectRepoProgressCompleted:
-    def test_completed_state_when_exact_match(self):
-        api = MockGitHubAPI(
-            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_COMPLETED},
-        )
-        result = collect_repo_progress(
-            "QualityOnDemand",
-            "https://github.com/camaraproject/QualityOnDemand",
-            api, [PUBLIC_RELEASE], PublishedContext("r3.2", None),
-        )
-        assert result.state == ProgressState.COMPLETED
-
-    def test_not_planned_when_version_mismatch(self):
-        api = MockGitHubAPI(
-            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_NONE_WITH_TAG},
-        )
-        result = collect_repo_progress(
-            "QualityOnDemand",
-            "https://github.com/camaraproject/QualityOnDemand",
-            api, [PUBLIC_RELEASE], PublishedContext("r3.2", None),
-        )
-        assert result.state == ProgressState.NOT_PLANNED
 
 
 class TestCollectHistoricalEntries:
@@ -904,7 +777,7 @@ class TestCollectAllWithHistorical:
 
         # Only QoD has a release-plan.yaml (with active plan)
         api = MockGitHubAPI(
-            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_COMPLETED},
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_NONE_FALL25},
         )
         result = collect_all(str(master_file), str(output_file), api=api)
 
@@ -943,20 +816,21 @@ class TestCollectAllWithHistorical:
         assert e.release_track == "independent"
         assert e.meta_release is None
 
-    def test_completed_repo_not_duplicated_as_historical(self, tmp_path):
+    def test_active_plan_repo_not_duplicated_as_historical(self, tmp_path):
         master_file = tmp_path / "releases-master.yaml"
         output_file = tmp_path / "releases-progress.yaml"
         master_file.write_text(yaml.dump(HISTORICAL_MASTER))
 
-        # QoD has a plan → should appear once as COMPLETED, not again as HISTORICAL
+        # QoD has a plan → should appear once as NOT_PLANNED (target_release_type=none),
+        # not again as HISTORICAL.
         api = MockGitHubAPI(
-            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_COMPLETED},
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_NONE_FALL25},
         )
         result = collect_all(str(master_file), str(output_file), api=api)
 
         qod_entries = [e for e in result.progress if e.repository == "QualityOnDemand"]
         assert len(qod_entries) == 1
-        assert qod_entries[0].state == ProgressState.COMPLETED
+        assert qod_entries[0].state == ProgressState.NOT_PLANNED
 
 
 class TestKPIStatistics:

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -176,17 +176,6 @@ class TestProgressData:
 
 
 class TestNewStates:
-    def test_completed_state_serializes(self):
-        entry = ProgressEntry(
-            repository="FallRepo",
-            github_url="https://github.com/camaraproject/FallRepo",
-            state=ProgressState.COMPLETED,
-            target_release_type="none",
-        )
-        d = entry.to_dict()
-        assert d["state"] == "completed"
-        assert "source" not in d
-
     def test_historical_state_serializes_with_source(self):
         entry = ProgressEntry(
             repository="OldRepo",


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Two coupled changes to the Release Progress Tracker viewer:

- **State-badge tooltips.** Each state badge now shows a short description on hover, mirroring the existing CSS-driven `.warning-tooltip` pattern (instant, forgiving target area, dark pill above the badge — flips below for the top two rows via the existing `tooltip-below-row` class).
- **Drop the `completed` state** per the 2026-04-28 ReleaseManagement call. The `ProgressState.COMPLETED` enum value, the `_check_completed_state()` upgrade path, and the schema enum value are removed. Entries with `target_release_type: none` now stay `not_planned` regardless of whether the plan exactly matches the last public release.

The rendered `not_planned` pill is now an em-dash (`—`) so the table de-emphasizes inactive plans visually; the state-filter dropdown shows "Not Planned" for clarity. Schema descriptions were rewritten as the source of truth for tooltip text:

```
- not_planned:    target_release_type: none — no active release planned
- planned:        Release planned, no release artifacts yet
- snapshot_active: Release-snapshot branch exists; review in progress
- draft_ready:    Snapshot branch + draft release ready for publication
- published:      Release tag published
- historical:     No active release-plan.yaml; entry derived from releases-master.yaml only
```

#### Which issue(s) this PR fixes:

Fixes #222

#### Special notes for reviewers:

`python3 -m pytest workflows/release-progress-tracker/tests/ -q` → 139 passed (was 151; 12 COMPLETED-related tests dropped, no new tests needed — tooltip is a CSS+template change with no unit-test surface).

Visual check: render the viewer locally against a `releases-progress.yaml` data file and hover any state badge. Existing data files still contain `state: completed` rows from before the merge; those will resolve to `not_planned` on the next collector run after this PR lands.

#### Changelog input

```
 release-note
Release Progress Tracker: state badges show description on hover; the "completed" upgrade-state is removed.
```

#### Additional documentation

```
docs
```
