### PR TITLE
Harden campaign actions against transient GraphQL failures

### DIFF
--- a/actions/campaign-finalize-issue-per-repo/action.yml
+++ b/actions/campaign-finalize-issue-per-repo/action.yml
@@ -97,17 +97,15 @@ runs:
       if: ${{ inputs.mode == 'apply' && steps.action.outputs.action == 'create' }}
       shell: bash
       run: |
-        # Check if automated label exists, create if not
-        if ! gh label list --repo "${{ inputs.repo }}" --json name --jq '.[].name' | grep -q "^automated$"; then
-          echo "Creating 'automated' label..."
-          gh label create automated \
-            --repo "${{ inputs.repo }}" \
-            --description "Automated bulk operations from project-administration" \
-            --color d1d5db
-          echo "Label created"
-        else
-          echo "Label 'automated' already exists"
-        fi
+        # --force is idempotent: creates the label if missing, updates color +
+        # description if it already exists. Avoids the GraphQL existence probe,
+        # which silently returns empty on transient 504s.
+        gh label create automated \
+          --repo "${{ inputs.repo }}" \
+          --description "Automated bulk operations from project-administration" \
+          --color d1d5db \
+          --force
+        echo "Label 'automated' ensured"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 

--- a/actions/campaign-finalize-per-repo/action.yml
+++ b/actions/campaign-finalize-per-repo/action.yml
@@ -198,16 +198,14 @@ runs:
       shell: bash
       working-directory: repo
       run: |
-        # Check if campaign label exists, create if not
-        if ! gh label list --json name --jq '.[].name' | grep -q "^${{ inputs.label_name }}$"; then
-          echo "Creating '${{ inputs.label_name }}' label..."
-          gh label create "${{ inputs.label_name }}" \
-            --description "${{ inputs.label_description }}" \
-            --color "${{ inputs.label_color }}"
-          echo "Label created"
-        else
-          echo "Label '${{ inputs.label_name }}' already exists"
-        fi
+        # --force is idempotent: creates the label if missing, updates color +
+        # description if it already exists. Avoids the GraphQL existence probe,
+        # which silently returns empty on transient 504s.
+        gh label create "${{ inputs.label_name }}" \
+          --description "${{ inputs.label_description }}" \
+          --color "${{ inputs.label_color }}" \
+          --force
+        echo "Label '${{ inputs.label_name }}' ensured"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 

--- a/actions/campaign-reconcile-per-repo/action.yml
+++ b/actions/campaign-reconcile-per-repo/action.yml
@@ -318,6 +318,10 @@ runs:
     # 7. APPLY — create PR (only if no PR on stable branch yet)
     # Force-push on an existing PR updates it automatically.
     # ─────────────────────────────────────────────────────────────────────
+    # tree_match=true with pr_exists=false is the orphan-branch recovery path:
+    # a previous run pushed the branch but failed before creating the PR
+    # (e.g., transient GraphQL 504). Fall through to create the missing PR
+    # on the existing branch instead of skipping under the preserve-approvals path.
     - name: APPLY - Create PR
       id: pr_create
       if: |
@@ -325,7 +329,7 @@ runs:
         && inputs.error_occurred != 'true'
         && steps.verify_authorship.outputs.aborted != 'true'
         && steps.change_check.outputs.changed == 'true'
-        && steps.push.outputs.pushed == 'true'
+        && (steps.push.outputs.pushed == 'true' || steps.push.outputs.tree_match == 'true')
         && steps.detect.outputs.pr_exists != 'true'
       shell: bash
       working-directory: repo

--- a/actions/campaign-reconcile-per-repo/action.yml
+++ b/actions/campaign-reconcile-per-repo/action.yml
@@ -220,14 +220,15 @@ runs:
       shell: bash
       working-directory: repo
       run: |
-        if ! gh label list --json name --jq '.[].name' | grep -q "^${{ inputs.label_name }}$"; then
-          gh label create "${{ inputs.label_name }}" \
-            --description "${{ inputs.label_description }}" \
-            --color "${{ inputs.label_color }}"
-          echo "Label '${{ inputs.label_name }}' created"
-        else
-          echo "Label '${{ inputs.label_name }}' already exists"
-        fi
+        # --force is idempotent: creates the label if missing, updates color +
+        # description if it already exists. Avoids the GraphQL existence probe,
+        # which silently returns empty on transient 504s and led the script to
+        # attempt a create that then failed with "label already exists".
+        gh label create "${{ inputs.label_name }}" \
+          --description "${{ inputs.label_description }}" \
+          --color "${{ inputs.label_color }}" \
+          --force
+        echo "Label '${{ inputs.label_name }}' ensured"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 


### PR DESCRIPTION
**What type of PR is this?**

- [x] bug

**What this PR does / why we need it**
Two independent campaign-action hardening fixes against transient GraphQL 504s, observed in the 2026-05-11 mass-onboarding dispatch.

1. `campaign-reconcile-per-repo`: extend the create-PR gate so that `tree_match=true` with no open PR (orphan-branch recovery) also fires it. Today the orphan-branch path is silently skipped under the preserve-approvals branch.
2. Three label-ensure steps: drop the `gh label list` GraphQL probe and use `gh label create --force`. Idempotent — creates if missing, updates color/description otherwise.

**Which issue(s) this PR fixes**
Fixes #233

**Special notes for reviewers**
Commits are independent and reviewable separately.

**Changelog input**
- Fix: campaign-reconcile-per-repo now creates the missing PR when retry sees a matching tree but no open PR (orphan-branch recovery).
- Fix: campaign label-ensure steps use `gh label create --force` instead of probing via `gh label list`; removes a transient-GraphQL failure mode.

**Additional documentation**
None.
