### PR TITLE
fix(release-progress): author tracker update commits as CLA-approved app bot

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -247,8 +247,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "camara-release-automation[bot]"
+          git config user.email "261643975+camara-release-automation[bot]@users.noreply.github.com"
           git fetch origin main
 
           PR_DATA=$(gh pr list --head "${{ github.repository_owner }}:$BRANCH" \

--- a/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
+++ b/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
@@ -44,3 +44,17 @@ def test_data_pr_preserves_existing_pr_when_generated_tree_is_unchanged():
 
     assert "No changes detected compared to existing $BRANCH branch" in workflow_text
     assert "pr_action=unchanged_existing_pr" in workflow_text
+
+
+def test_data_pr_commit_author_is_cla_covered_app_bot():
+    # The update commit must be authored by the EasyCLA-approved release-automation
+    # App bot, not github-actions[bot] — otherwise EasyCLA reports "Missing CLA
+    # Authorization" and the PR check fails.
+    workflow_text = WORKFLOW_PATH.read_text()
+
+    assert 'git config user.name "camara-release-automation[bot]"' in workflow_text
+    assert (
+        "261643975+camara-release-automation[bot]@users.noreply.github.com"
+        in workflow_text
+    )
+    assert "github-actions[bot]" not in workflow_text


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The tracker's update commit was authored by `github-actions[bot]`, which is not on the EasyCLA approved list, so tracker update PRs failed the EasyCLA check. This authors the commit as the `camara-release-automation` app bot — the approved identity that already pushes the branch — and adds a contract test pinning it.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

#### Changelog input

```
 release-note

Tracker update PRs are now authored by the release-automation app bot so they pass EasyCLA.
```

#### Additional documentation 

This section can be blank.

```
docs

```
