### PR TITLE
fix(release-progress): reset stale update branch instead of aborting

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -270,11 +270,8 @@ jobs:
           fi
 
           if [ "$REMOTE_EXISTS" = "true" ]; then
-            if [ -z "$PR_NUMBER" ] || [ "$PR_TITLE" != "$TITLE" ]; then
-              echo "::error::Existing $BRANCH branch has no matching open PR with title '$TITLE'. Refusing to overwrite it."
-              exit 1
-            fi
-
+            # Primary safety gate: never overwrite a branch that carries any commit
+            # other than the tracker's own automation commit.
             NON_AUTOMATION_COMMITS=$(
               git log --format=%s "origin/main..origin/$BRANCH" \
                 | grep -Fvx "$COMMIT_MESSAGE" || true
@@ -285,12 +282,25 @@ jobs:
               exit 1
             fi
 
-            if git diff --quiet "origin/$BRANCH" -- data/; then
-              echo "No changes detected compared to existing $BRANCH branch"
-              echo "pr_action=unchanged_existing_pr" >> $GITHUB_OUTPUT
-              echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-              echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-              exit 0
+            if [ -n "$PR_NUMBER" ]; then
+              # An open PR claims the branch: its title must be the automation title,
+              # otherwise a human has repurposed it and we must not overwrite.
+              if [ "$PR_TITLE" != "$TITLE" ]; then
+                echo "::error::Existing open PR #$PR_NUMBER on $BRANCH has unexpected title '$PR_TITLE'. Refusing to overwrite it."
+                exit 1
+              fi
+
+              if git diff --quiet "origin/$BRANCH" -- data/; then
+                echo "No changes detected compared to existing $BRANCH branch"
+                echo "pr_action=unchanged_existing_pr" >> $GITHUB_OUTPUT
+                echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+                echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            else
+              # Stale automation branch left over from a merged/closed PR whose
+              # branch was not deleted. Safe to reset and open a fresh PR.
+              echo "Existing $BRANCH branch has no open PR; resetting stale automation branch."
             fi
           fi
 

--- a/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
+++ b/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
@@ -34,9 +34,29 @@ def test_data_pr_updates_stable_branch_safely():
     workflow_text = WORKFLOW_PATH.read_text()
 
     assert "--force-with-lease=refs/heads/$BRANCH:$REMOTE_SHA" in workflow_text
-    assert "Existing $BRANCH branch has no matching open PR" in workflow_text
     assert "origin/main..origin/$BRANCH" in workflow_text
     assert 'gh pr list --head "${{ github.repository_owner }}:$BRANCH"' in workflow_text
+
+
+def test_data_pr_refuses_branch_with_non_automation_commits():
+    # The non-automation-commit check is the primary safety gate against
+    # overwriting work that is not the tracker's own update commit.
+    workflow_text = WORKFLOW_PATH.read_text()
+
+    assert (
+        "contains non-automation commits. Refusing to overwrite it."
+        in workflow_text
+    )
+
+
+def test_data_pr_resets_stale_branch_without_open_pr():
+    # A leftover automation branch from a merged/closed PR (branch not deleted)
+    # must be reset and a fresh PR opened, not treated as an error.
+    workflow_text = WORKFLOW_PATH.read_text()
+
+    assert "has no open PR; resetting stale automation branch" in workflow_text
+    # The old hard-fail on a missing open PR must not return.
+    assert "has no matching open PR" not in workflow_text
 
 
 def test_data_pr_preserves_existing_pr_when_generated_tree_is_unchanged():


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

When the `release-progress-update` branch already exists but has no open PR — the normal state after a merged tracker PR whose branch was not deleted — the stable-update step aborted with "no matching open PR. Refusing to overwrite it." This makes the non-automation-commit check the primary safety gate and resets such a leftover branch into a fresh PR, refusing on a title mismatch only when an open PR actually exists. Contract tests cover both paths.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

#### Changelog input

```
 release-note

The tracker now resets a leftover update branch from a merged PR instead of failing.
```

#### Additional documentation 

This section can be blank.

```
docs

```
