### PR TITLE
fix(release-progress): add Spring26 tracker mappings

### DIFF
--- a/config/meta-release-mappings.yaml
+++ b/config/meta-release-mappings.yaml
@@ -101,18 +101,3 @@ mappings:
   Spring26:
     ClickToDial: "r1"
     NetworkSliceBooking: "r2"
-
-# Special cases for repositories that don't follow standard patterns
-exceptions:
-  # Repository splits (original -> new repositories)
-  splits:
-    DeviceStatus:
-      # DeviceStatus was split into multiple repositories
-      original_release_cycles: ["r1", "r2"]
-      new_repositories:
-        DeviceRoaming:
-          starts_from: "r1"
-          contains_apis: ["roaming-status"]
-        ConnectivityInsights:
-          starts_from: "r1"
-          contains_apis: ["connectivity-status", "device-reachability"]

--- a/config/meta-release-mappings.yaml
+++ b/config/meta-release-mappings.yaml
@@ -96,6 +96,12 @@ mappings:
     VerifiedCaller: "r1"
     WebRTC: "r2"
 
+  # Spring 2026 Meta-Release
+  # Target: March 2026
+  Spring26:
+    ClickToDial: "r1"
+    NetworkSliceBooking: "r2"
+
 # Special cases for repositories that don't follow standard patterns
 exceptions:
   # Repository splits (original -> new repositories)
@@ -110,8 +116,3 @@ exceptions:
         ConnectivityInsights:
           starts_from: "r1"
           contains_apis: ["connectivity-status", "device-reachability"]
-
-# Pre-Fall24 repositories that should be excluded
-excluded_repositories:
-  - "Test-repository"
-  - "Template-repository"

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -375,7 +375,7 @@ tr.historical-row:hover td {
     const COL_COUNT = 9;
 
     // Release track display order — update when new meta-releases are added
-    const TRACK_ORDER = ['Spring26', 'Sync26', 'Signal27', 'independent', 'Fall25', 'Spring25', 'Fall24'];
+    const TRACK_ORDER = ['Sync26', 'Signal27', 'independent', 'Spring26', 'Fall25', 'Spring25', 'Fall24'];
 
     // Global state
     let allRows = [];


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds Spring26 release-cycle mappings for ClickToDial r1 and NetworkSliceBooking r2 so a full Release Collector run classifies their historical Spring26 releases as Spring26 instead of Independent.

Updates the Release Progress Tracker order so active and future tracks stay first and Spring26 appears with historical releases after Independent.

Removes unused example-only configuration from the mapping file; those entries were not consumed by the Release Collector or Release Progress Tracker.

#### Which issue(s) this PR fixes:

Fixes https://github.com/camaraproject/ReleaseManagement/issues/585

#### Special notes for reviewers:

ReleaseTest is no longer included through Release Collector repository discovery because the API repository topic has been removed from that repository.

#### Changelog input

```
release-note
Fix Spring26 release progress tracker mappings and ordering.
```

#### Additional documentation

This section can be blank.

```
docs
```