### PR TITLE
fix(release-collector): add Spring26 portfolio column

### DIFF
--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -354,7 +354,8 @@
               <th onclick="sortMetaReleaseTable(2)">Fall24 <span class="sort-arrow"></span></th>
               <th onclick="sortMetaReleaseTable(3)">Spring25 <span class="sort-arrow"></span></th>
               <th onclick="sortMetaReleaseTable(4)">Fall25 <span class="sort-arrow"></span></th>
-              <th onclick="sortMetaReleaseTable(5)">First Release <span class="sort-arrow"></span></th>
+              <th onclick="sortMetaReleaseTable(5)">Spring26 <span class="sort-arrow"></span></th>
+              <th onclick="sortMetaReleaseTable(6)">First Release <span class="sort-arrow"></span></th>
             </tr>
           </thead>
           <tbody id="metaReleaseTableBody">
@@ -362,7 +363,7 @@
         </table>
         <div class="footer-note"
           style="margin-top: 15px; padding: 10px; background: #f8f9fa; border-radius: 6px; font-size: 13px; color: #666;">
-          Note: This table shows only meta-releases (Fall24, Spring25, Fall25). Independent releases are shown in API
+          Note: This table shows only meta-releases (Fall24, Spring25, Fall25, Spring26). Independent releases are shown in API
           Evolution and Repository views.
         </div>
       </div>
@@ -397,7 +398,7 @@
     let showOnlyLatestPatches = true; // Default: show only latest patches
 
     // Meta-release constants
-    const META_RELEASES = ['Fall24', 'Spring25', 'Fall25'];
+    const META_RELEASES = ['Fall24', 'Spring25', 'Fall25', 'Spring26'];
     const INDEPENDENT_RELEASE = 'Independent';
 
     /**
@@ -533,7 +534,8 @@
           first_release: firstAPI.first_release,
           fall24: null,
           spring25: null,
-          fall25: null
+          fall25: null,
+          spring26: null
         };
 
         metaVersions.forEach(v => {
@@ -543,6 +545,8 @@
             row.spring25 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
           } else if (v.meta_release === 'Fall25') {
             row.fall25 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
+          } else if (v.meta_release === 'Spring26') {
+            row.spring26 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
           }
         });
 
@@ -833,6 +837,19 @@
           fall25Cell.innerHTML = '<span class="empty-cell">-</span>';
         }
         tr.appendChild(fall25Cell);
+
+        // Spring26
+        const spring26Cell = document.createElement('td');
+        spring26Cell.className = 'release-cell';
+        if (row.spring26) {
+          spring26Cell.innerHTML = `
+            <div class="version-badge">${row.spring26.api_version}</div>
+            ${ViewerLib.renderMaturityBadge(row.spring26.maturity)}
+          `;
+        } else {
+          spring26Cell.innerHTML = '<span class="empty-cell">-</span>';
+        }
+        tr.appendChild(spring26Cell);
 
         // First Release
         const firstReleaseCell = document.createElement('td');

--- a/workflows/release-collector/tests/test_portfolio_template.py
+++ b/workflows/release-collector/tests/test_portfolio_template.py
@@ -1,0 +1,40 @@
+import ast
+import re
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "portfolio-template.html"
+EXPECTED_META_RELEASES = ["Fall24", "Spring25", "Fall25", "Spring26"]
+
+
+def read_template():
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_meta_release_table_headers_include_spring26_in_order():
+    template = read_template()
+
+    header_matches = re.findall(
+        r'<th onclick="sortMetaReleaseTable\(\d+\)">([^<]+)',
+        template,
+    )
+    header_labels = [label.strip() for label in header_matches]
+
+    assert header_labels == ["API", "Category", *EXPECTED_META_RELEASES, "First Release"]
+
+
+def test_spring26_is_mapped_from_source_data_to_rendered_rows():
+    template = read_template()
+
+    meta_release_match = re.search(r"const META_RELEASES = (\[[^\]]+\]);", template)
+    assert meta_release_match is not None
+    assert ast.literal_eval(meta_release_match.group(1)) == EXPECTED_META_RELEASES
+
+    assert "spring26: null" in template
+    assert "v.meta_release === 'Spring26'" in template
+    expected_assignment = (
+        "row.spring26 = "
+        "{ api_version: v.api_version, maturity: v.maturity, isNew: v.isNew }"
+    )
+    assert expected_assignment in template
+    assert "row.spring26.api_version" in template


### PR DESCRIPTION
#### What type of PR is this?

correction
tests


#### What this PR does / why we need it:

Adds the Spring26 column to the Portfolio Overview Meta-Release Table so Spring26 releases appear alongside Fall24, Spring25, and Fall25. The template now includes Spring26 in the table header, meta-release filter, row mapping, and rendered release cell.

Adds a focused regression test for the portfolio template column order and Spring26 row mapping.


#### Which issue(s) this PR fixes:

None.

#### Special notes for reviewers:

Validation:
- python3 -m pytest workflows/release-collector/tests/test_portfolio_template.py -q
- node workflows/release-collector/scripts/generate-viewers.js
- node workflows/release-collector/scripts/validate-landscape.js

#### Changelog input

```
release-note
Add Spring26 to the release-collector Portfolio Overview Meta-Release Table.
```

#### Additional documentation

This section can be blank.

```
docs
```
