### PR TITLE
fix(release-collector): add Spring26 meta-release viewer

### DIFF
--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -250,6 +250,7 @@ jobs:
             "viewers/fall24.html"
             "viewers/spring25.html"
             "viewers/fall25.html"
+            "viewers/spring26.html"
             "viewers/portfolio.html"
           )
 
@@ -328,6 +329,7 @@ jobs:
           cp artifact/fall24.html production-site/${{ env.PRODUCTION_PATH }}/
           cp artifact/spring25.html production-site/${{ env.PRODUCTION_PATH }}/
           cp artifact/fall25.html production-site/${{ env.PRODUCTION_PATH }}/
+          cp artifact/spring26.html production-site/${{ env.PRODUCTION_PATH }}/
           cp artifact/portfolio.html production-site/${{ env.PRODUCTION_PATH }}/
 
           # Copy production index as index.html
@@ -766,6 +768,7 @@ jobs:
             echo "| fall24.html | Fall 2024 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
             echo "| spring25.html | Spring 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
             echo "| fall25.html | Fall 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
+            echo "| spring26.html | Spring 2026 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
             echo "| portfolio.html | Portfolio overview |" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -511,7 +511,7 @@ jobs:
           done
 
           # Check HTML viewers exist
-          for viewer in fall24 spring25 fall25 portfolio internal; do
+          for viewer in fall24 spring25 fall25 spring26 portfolio internal; do
             if [ ! -f "viewers/${viewer}.html" ]; then
               echo "WARNING: Viewer ${viewer}.html not found"
             else
@@ -593,7 +593,7 @@ jobs:
             This PR updates the CAMARA release tracking data:
 
             - 📊 `data/releases-master.yaml` - Master release metadata
-            - 📈 `reports/*.json` - Meta-release reports (Fall24, Spring25, Fall25, All)
+            - 📈 `reports/*.json` - Meta-release reports (Fall24, Spring25, Fall25, Spring26, All)
             - 📦 `data/release-artifacts/` - Per-release metadata files (if generated)
 
             **Note**: Viewers are deployed to staging for preview. After merging, trigger the **Release Collector - Production Deploy** workflow to publish viewers and upload metadata to GitHub releases.
@@ -631,6 +631,7 @@ jobs:
             - [Fall24 Viewer](https://${{ github.repository_owner }}.github.io/project-administration/fall24.html)
             - [Spring25 Viewer](https://${{ github.repository_owner }}.github.io/project-administration/spring25.html)
             - [Fall25 Viewer](https://${{ github.repository_owner }}.github.io/project-administration/fall25.html)
+            - [Spring26 Viewer](https://${{ github.repository_owner }}.github.io/project-administration/spring26.html)
             - [Portfolio Viewer](https://${{ github.repository_owner }}.github.io/project-administration/portfolio.html)
             - [Internal Admin View](https://${{ github.repository_owner }}.github.io/project-administration/internal.html)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repository provides:
 Automated collection and tracking of CAMARA API releases.
 
 * **Location**: [workflows/release-collector/](workflows/release-collector/)
-* **Features**: Daily automated check for updates, creation of releases-master.yaml, data enrichment for reports, interactive HTML viewers for meta-releases (Fall24, Spring25, Fall25) and complete API portfolio. Manual deployment to production website with separate workflow.
+* **Features**: Daily automated check for updates, creation of releases-master.yaml, data enrichment for reports, interactive HTML viewers for meta-releases (Fall24, Spring25, Fall25, Spring26) and complete API portfolio. Manual deployment to production website with separate workflow.
 * **Documentation**: [workflows/release-collector/docs/README.md](workflows/release-collector/docs/README.md)
 * **Workflows**: `release-collector.yml`, `release-collector-production.yml`
 
@@ -53,14 +53,14 @@ Automated collection and tracking of CAMARA API releases.
 Configuration files used by the Release Collector (at repository root level):
 
 * **API Landscape**: [config/api-landscape.yaml](config/api-landscape.yaml) - Portfolio metadata (categories, URLs, tooltips) for API enrichment
-* **Meta-Release Mappings**: [config/meta-release-mappings.yaml](config/meta-release-mappings.yaml) - Maps repository release cycles (r1, r2, r3) to meta-releases (Fall24, Spring25, Fall25)
+* **Meta-Release Mappings**: [config/meta-release-mappings.yaml](config/meta-release-mappings.yaml) - Maps repository release cycles (r1, r2, r3) to meta-releases (Fall24, Spring25, Fall25, Spring26)
 
 #### Release Collector Outputs
 
 Generated and maintained by the Release Collector system:
 
 * **Data**: [data/releases-master.yaml](data/releases-master.yaml) - Master release metadata for all CAMARA API releases
-* **Reports**: [reports/](reports/) - JSON files (all-releases, fall24, spring25, fall25)
+* **Reports**: [reports/](reports/) - JSON files (all-releases, fall24, spring25, fall25, spring26)
 * **Viewers**: Interactive HTML viewers are not committed, but deployed for review in staging to https://camaraproject.github.io/project-administration/. Deployment to production website manually triggered with `release-collector-production.yml`.
 
 ### Campaigns

--- a/reports/all-releases.json
+++ b/reports/all-releases.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generated": "2026-06-19T17:57:41.268Z",
+    "generated": "2026-06-20T13:01:52.434Z",
     "meta_release": "All",
     "source": "Release Collector v3",
     "landscape_version": "1.1.1"
@@ -1242,7 +1242,8 @@
           "display_name": "Click to Dial Service",
           "published": true,
           "canonical_name": "click-to-dial",
-          "first_release": "Spring26"
+          "first_release": "Spring26",
+          "isNew": true
         }
       ]
     },
@@ -3049,7 +3050,8 @@
           "display_name": "Network Slice Booking",
           "published": true,
           "canonical_name": "network-slice-booking",
-          "first_release": "Fall25"
+          "first_release": "Fall25",
+          "isNew": false
         },
         {
           "api_name": "network-slice-assignment",
@@ -3063,7 +3065,8 @@
           "display_name": "Network Slice Assignment",
           "published": true,
           "canonical_name": "network-slice-assignment",
-          "first_release": "Spring26"
+          "first_release": "Spring26",
+          "isNew": true
         }
       ]
     },
@@ -4744,6 +4747,7 @@
       "published": true,
       "canonical_name": "click-to-dial",
       "first_release": "Spring26",
+      "isNew": true,
       "repository": "ClickToDial",
       "release_tag": "r1.4",
       "release_date": "2026-06-01T17:46:34Z",
@@ -6532,6 +6536,7 @@
       "published": true,
       "canonical_name": "network-slice-assignment",
       "first_release": "Spring26",
+      "isNew": true,
       "repository": "NetworkSliceBooking",
       "release_tag": "r2.3",
       "release_date": "2026-06-04T06:15:02Z",
@@ -6573,6 +6578,7 @@
       "published": true,
       "canonical_name": "network-slice-booking",
       "first_release": "Fall25",
+      "isNew": false,
       "repository": "NetworkSliceBooking",
       "release_tag": "r2.3",
       "release_date": "2026-06-04T06:15:02Z",

--- a/reports/fall24.json
+++ b/reports/fall24.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generated": "2026-06-19T17:57:41.282Z",
+    "generated": "2026-06-20T13:01:52.461Z",
     "meta_release": "Fall24",
     "source": "Release Collector v3",
     "landscape_version": "1.1.1"

--- a/reports/fall25.json
+++ b/reports/fall25.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generated": "2026-06-19T17:57:41.285Z",
+    "generated": "2026-06-20T13:01:52.475Z",
     "meta_release": "Fall25",
     "source": "Release Collector v3",
     "landscape_version": "1.1.1"

--- a/reports/spring25.json
+++ b/reports/spring25.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generated": "2026-06-19T17:57:41.284Z",
+    "generated": "2026-06-20T13:01:52.469Z",
     "meta_release": "Spring25",
     "source": "Release Collector v3",
     "landscape_version": "1.1.1"

--- a/reports/spring26.json
+++ b/reports/spring26.json
@@ -1,0 +1,195 @@
+{
+  "metadata": {
+    "generated": "2026-06-20T13:01:52.482Z",
+    "meta_release": "Spring26",
+    "source": "Release Collector v3",
+    "landscape_version": "1.1.1"
+  },
+  "statistics": {
+    "repositories_count": 2,
+    "api_versions_count": 3,
+    "unique_api_names_count": 3,
+    "unique_apis_count": 3,
+    "api_version_maturity": {
+      "stable": 0,
+      "initial": 3,
+      "rc": 0
+    },
+    "unique_api_maturity": {
+      "stable": 0,
+      "initial": 3,
+      "rc": 0
+    },
+    "categories": {
+      "Communication Services": 1,
+      "Communication Quality": 2
+    },
+    "apis_with_previous_names": 0
+  },
+  "repositories": {
+    "ClickToDial": {
+      "releases": [
+        {
+          "tag": "r1.4",
+          "date": "2026-06-01T17:46:34Z",
+          "apis_count": 1
+        }
+      ],
+      "total_apis": 1,
+      "unique_apis_count": 1
+    },
+    "NetworkSliceBooking": {
+      "releases": [
+        {
+          "tag": "r2.3",
+          "date": "2026-06-04T06:15:02Z",
+          "apis_count": 2
+        }
+      ],
+      "total_apis": 2,
+      "unique_apis_count": 2
+    }
+  },
+  "releases": [
+    {
+      "repository": "ClickToDial",
+      "release_tag": "r1.4",
+      "release_date": "2026-06-01T17:46:34Z",
+      "meta_release": "Spring26",
+      "github_url": "https://github.com/camaraproject/ClickToDial/releases/tag/r1.4",
+      "release_type": "public-release",
+      "src_commit_sha": "b2308cb8035cb0237550a97e1caab297d3d88d03",
+      "dependencies": {
+        "commonalities_release": "r4.3 (0.8.0)",
+        "identity_consent_management_release": "r4.2 (0.5.0)"
+      },
+      "apis": [
+        {
+          "api_name": "click-to-dial",
+          "api_version": "0.1.0",
+          "api_title": "Click to Dial Service",
+          "commonalities": "0.8.0",
+          "maturity": "initial",
+          "portfolio_category": "Communication Services",
+          "website_url": "https://camaraproject.org/click-to-dial/",
+          "tooltip": "Establish web-based communication by clicking an object",
+          "display_name": "Click to Dial Service",
+          "published": true,
+          "canonical_name": "click-to-dial",
+          "first_release": "Spring26",
+          "isNew": true
+        }
+      ]
+    },
+    {
+      "repository": "NetworkSliceBooking",
+      "release_tag": "r2.3",
+      "release_date": "2026-06-04T06:15:02Z",
+      "meta_release": "Spring26",
+      "github_url": "https://github.com/camaraproject/NetworkSliceBooking/releases/tag/r2.3",
+      "release_type": "public-release",
+      "src_commit_sha": "e64cf3d8830bcc61689c82cf5e600486cdd45fbc",
+      "dependencies": {
+        "commonalities_release": "r4.3 (0.8.0)",
+        "identity_consent_management_release": "r4.2 (0.5.0)"
+      },
+      "apis": [
+        {
+          "api_name": "network-slice-booking",
+          "api_version": "0.2.0",
+          "api_title": "Network Slice Booking",
+          "commonalities": "0.8.0",
+          "maturity": "initial",
+          "portfolio_category": "Communication Quality",
+          "website_url": "https://camaraproject.org/network-slice-booking/",
+          "tooltip": "Reserve, dynamically provision, query, dynamically delete a slice",
+          "display_name": "Network Slice Booking",
+          "published": true,
+          "canonical_name": "network-slice-booking",
+          "first_release": "Fall25",
+          "isNew": false
+        },
+        {
+          "api_name": "network-slice-assignment",
+          "api_version": "0.1.0",
+          "api_title": "Network Slice Assignment",
+          "commonalities": "0.8.0",
+          "maturity": "initial",
+          "portfolio_category": "Communication Quality",
+          "website_url": "https://camaraproject.org/network-slice-assignment/",
+          "tooltip": "Assign end user devices to slices. Check that slice capacity is not exceeded.",
+          "display_name": "Network Slice Assignment",
+          "published": true,
+          "canonical_name": "network-slice-assignment",
+          "first_release": "Spring26",
+          "isNew": true
+        }
+      ]
+    }
+  ],
+  "apis": [
+    {
+      "api_name": "click-to-dial",
+      "api_version": "0.1.0",
+      "api_title": "Click to Dial Service",
+      "commonalities": "0.8.0",
+      "maturity": "initial",
+      "portfolio_category": "Communication Services",
+      "website_url": "https://camaraproject.org/click-to-dial/",
+      "tooltip": "Establish web-based communication by clicking an object",
+      "display_name": "Click to Dial Service",
+      "published": true,
+      "canonical_name": "click-to-dial",
+      "first_release": "Spring26",
+      "isNew": true,
+      "repository": "ClickToDial",
+      "release_tag": "r1.4",
+      "release_date": "2026-06-01T17:46:34Z",
+      "meta_release": "Spring26",
+      "github_url": "https://github.com/camaraproject/ClickToDial/releases/tag/r1.4",
+      "release_type": "public-release"
+    },
+    {
+      "api_name": "network-slice-assignment",
+      "api_version": "0.1.0",
+      "api_title": "Network Slice Assignment",
+      "commonalities": "0.8.0",
+      "maturity": "initial",
+      "portfolio_category": "Communication Quality",
+      "website_url": "https://camaraproject.org/network-slice-assignment/",
+      "tooltip": "Assign end user devices to slices. Check that slice capacity is not exceeded.",
+      "display_name": "Network Slice Assignment",
+      "published": true,
+      "canonical_name": "network-slice-assignment",
+      "first_release": "Spring26",
+      "isNew": true,
+      "repository": "NetworkSliceBooking",
+      "release_tag": "r2.3",
+      "release_date": "2026-06-04T06:15:02Z",
+      "meta_release": "Spring26",
+      "github_url": "https://github.com/camaraproject/NetworkSliceBooking/releases/tag/r2.3",
+      "release_type": "public-release"
+    },
+    {
+      "api_name": "network-slice-booking",
+      "api_version": "0.2.0",
+      "api_title": "Network Slice Booking",
+      "commonalities": "0.8.0",
+      "maturity": "initial",
+      "portfolio_category": "Communication Quality",
+      "website_url": "https://camaraproject.org/network-slice-booking/",
+      "tooltip": "Reserve, dynamically provision, query, dynamically delete a slice",
+      "display_name": "Network Slice Booking",
+      "published": true,
+      "canonical_name": "network-slice-booking",
+      "first_release": "Fall25",
+      "isNew": false,
+      "repository": "NetworkSliceBooking",
+      "release_tag": "r2.3",
+      "release_date": "2026-06-04T06:15:02Z",
+      "meta_release": "Spring26",
+      "github_url": "https://github.com/camaraproject/NetworkSliceBooking/releases/tag/r2.3",
+      "release_type": "public-release"
+    }
+  ]
+}

--- a/workflows/release-collector/QUICKSTART.md
+++ b/workflows/release-collector/QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ## What This Does
 
-Automatically tracks all CAMARA API releases across repositories (including pre-releases), categorizes them by meta-release (Fall24, Spring25, Fall25), and generates browsable HTML viewers. Also generates release-metadata files for each release.
+Automatically tracks all CAMARA API releases across repositories (including pre-releases), categorizes them by meta-release (Fall24, Spring25, Fall25, Spring26), and generates browsable HTML viewers. Also generates release-metadata files for each release.
 
 ## Scheduled Runs
 
@@ -83,7 +83,7 @@ After merging the PR, deploy viewers and upload release metadata to the public s
 
 3. **What Happens**
    - Viewers are published to: https://camaraproject.github.io/releases/
-   - Links: [Fall24](https://camaraproject.github.io/releases/fall24.html) | [Spring25](https://camaraproject.github.io/releases/spring25.html) | [Fall25](https://camaraproject.github.io/releases/fall25.html)
+   - Links: [Spring26](https://camaraproject.github.io/releases/spring26.html) | [Fall25](https://camaraproject.github.io/releases/fall25.html) | [Spring25](https://camaraproject.github.io/releases/spring25.html) | [Fall24](https://camaraproject.github.io/releases/fall24.html)
    - Release-metadata files (YAML/JSON) uploaded to each GitHub release as assets
    - Upload report artifact generated showing NEW/UPDATE/CURRENT status for each release
 

--- a/workflows/release-collector/docs/README.md
+++ b/workflows/release-collector/docs/README.md
@@ -5,7 +5,7 @@
 
 ## What This Workflow Does
 
-Automatically tracks all CAMARA API releases across repositories, categorizes them by meta-release (Fall24, Spring25, Fall25), and generates browsable HTML reports showing API versions, maturity levels, and portfolio information.
+Automatically tracks all CAMARA API releases across repositories, categorizes them by meta-release (Fall24, Spring25, Fall25, Spring26), and generates browsable HTML reports showing API versions, maturity levels, and portfolio information.
 
 **For Maintainers**: See [QUICKSTART.md](../QUICKSTART.md) for a 2-minute guide and [MAINTAINER-FAQ.md](../MAINTAINER-FAQ.md) for common questions.
 
@@ -240,7 +240,8 @@ reports/
 ├── all-releases.json             # Complete dataset (enriched)
 ├── fall24.json                   # Fall 2024 meta-release
 ├── spring25.json                 # Spring 2025 meta-release
-└── fall25.json                   # Fall 2025 meta-release
+├── fall25.json                   # Fall 2025 meta-release
+└── spring26.json                 # Spring 2026 meta-release
 ```
 
 #### Deployed to Staging / Available in Artifacts (Not Committed)
@@ -250,6 +251,7 @@ viewers/
 ├── fall24.html                   # Fall 2024 viewer
 ├── spring25.html                 # Spring 2025 viewer
 ├── fall25.html                   # Fall 2025 viewer
+├── spring26.html                 # Spring 2026 viewer
 ├── portfolio.html                # Portfolio overview viewer (Alpha)
 └── internal.html                 # Internal admin viewer (Alpha)
 ```

--- a/workflows/release-collector/production-index.html
+++ b/workflows/release-collector/production-index.html
@@ -16,6 +16,7 @@
   <p>Interactive release tracking for CAMARA APIs</p>
 
   <h2>Meta-Release Viewers</h2>
+  <a href="spring26.html" class="viewer-link">Spring26 meta-release</a>
   <a href="fall25.html" class="viewer-link">Fall25 meta-release</a>
   <a href="spring25.html" class="viewer-link">Spring25 meta-release</a>
   <a href="fall24.html" class="viewer-link">Fall24 meta-release</a>

--- a/workflows/release-collector/schemas/master-metadata-schema.yaml
+++ b/workflows/release-collector/schemas/master-metadata-schema.yaml
@@ -93,7 +93,7 @@ properties:
         meta_release:
           type: string
           description: Assigned meta-release cycle from configuration
-          examples: ["Fall24", "Spring25", "Fall25", "Independent", "None"]
+          examples: ["Fall24", "Spring25", "Fall25", "Spring26", "Independent", "None"]
 
         github_url:
           type: string

--- a/workflows/release-collector/scripts/generate-reports.js
+++ b/workflows/release-collector/scripts/generate-reports.js
@@ -5,7 +5,7 @@
  *
  * Generates JSON report files for each meta-release from the master metadata.
  * Applies runtime enrichment from API landscape data.
- * Creates separate files for Fall24, Spring25, Fall25, PreFall24, Independent, etc.
+ * Creates separate files for Fall24, Spring25, Fall25, Spring26, PreFall24, Independent, etc.
  */
 
 const fs = require('fs');
@@ -27,6 +27,7 @@ const REPO_ROOT = path.join(__dirname, '..', '..', '..');
 const DATA_PATH = path.join(REPO_ROOT, 'data');
 const REPORTS_PATH = path.join(REPO_ROOT, 'reports');
 const MASTER_FILE = path.join(DATA_PATH, 'releases-master.yaml');
+const META_RELEASES = ['Fall24', 'Spring25', 'Fall25', 'Spring26'];
 
 /**
  * Load master metadata
@@ -148,10 +149,8 @@ async function main() {
   fs.writeFileSync(allFilepath, JSON.stringify(allReport, null, 2));
   console.log(`  ✓ all-releases.json - ${allReport.statistics.repositories_count} repos, ${allReport.statistics.apis_count} APIs`);
 
-  // 2. Generate reports for the three meta-releases only
-  const metaReleases = ['Fall24', 'Spring25', 'Fall25'];
-
-  for (const metaRelease of metaReleases) {
+  // 2. Generate reports for the public meta-releases only
+  for (const metaRelease of META_RELEASES) {
     if (grouped[metaRelease]) {
       // Re-enrich with specific meta-release for isNew calculation
       const metaReleaseData = landscape ?
@@ -208,6 +207,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  META_RELEASES,
   loadMaster,
   groupByMetaRelease,
   generateEnrichedReport

--- a/workflows/release-collector/scripts/generate-viewers.js
+++ b/workflows/release-collector/scripts/generate-viewers.js
@@ -19,6 +19,7 @@ const VIEWERS_DIR = path.join(ROOT_DIR, 'viewers');
 
 // Check for force regeneration flag from workflow
 const FORCE_REGENERATE = process.env.FORCE_REGENERATE === 'true';
+const META_RELEASE_VIEWERS = ['fall24', 'spring25', 'fall25', 'spring26'];
 
 /**
  * Check if viewer needs regeneration based on source file timestamps
@@ -41,6 +42,11 @@ async function shouldRegenerateViewer(release) {
     'fall25': {
       reportPath: path.join(REPORTS_DIR, 'fall25.json'),
       viewerPath: path.join(VIEWERS_DIR, 'fall25.html'),
+      template: 'meta-release-template.html'
+    },
+    'spring26': {
+      reportPath: path.join(REPORTS_DIR, 'spring26.json'),
+      viewerPath: path.join(VIEWERS_DIR, 'spring26.html'),
       template: 'meta-release-template.html'
     },
     'portfolio': {
@@ -342,7 +348,7 @@ async function generateAllViewers() {
     const results = [];
 
     // Determine which releases to generate
-    const releases = ['fall24', 'spring25', 'fall25'];
+    const releases = META_RELEASE_VIEWERS;
 
     // Check which reports exist
     const existingReleases = [];
@@ -464,12 +470,13 @@ Usage:
   node generate-viewers.js [release]
 
 Options:
-  release    Optional release name (fall24, spring25, fall25)
+  release    Optional release name (fall24, spring25, fall25, spring26)
              If omitted, generates all available releases
 
 Examples:
   node generate-viewers.js              # Generate all releases
   node generate-viewers.js fall25       # Generate only Fall25 viewer
+  node generate-viewers.js spring26     # Generate only Spring26 viewer
 `);
     process.exit(0);
   }
@@ -494,6 +501,7 @@ if (require.main === module) {
 
 // Export for potential use as module
 module.exports = {
+  META_RELEASE_VIEWERS,
   generateMetaReleaseViewer,
   generatePortfolioViewer,
   generateInternalViewer,

--- a/workflows/release-collector/scripts/lib/enrichment.js
+++ b/workflows/release-collector/scripts/lib/enrichment.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const META_RELEASES_WITH_IS_NEW = ['Fall24', 'Spring25', 'Fall25', 'Spring26'];
 
 /**
  * Load the API landscape configuration
@@ -99,7 +100,7 @@ function enrichAPI(api, landscape, currentMetaRelease = null) {
       canonical_name: api.api_name,
       first_release: 'Sandbox',  // Default for unknown APIs
       // Add isNew for meta-release reports
-      ...(currentMetaRelease && ['Fall24', 'Spring25', 'Fall25'].includes(currentMetaRelease) ? {
+      ...(currentMetaRelease && META_RELEASES_WITH_IS_NEW.includes(currentMetaRelease) ? {
         isNew: false  // Default to false for unknown APIs
       } : {})
     };
@@ -108,7 +109,7 @@ function enrichAPI(api, landscape, currentMetaRelease = null) {
   // Determine isNew based on first_release and current meta-release
   let isNew = false;
   if (currentMetaRelease && enrichment.first_release &&
-      ['Fall24', 'Spring25', 'Fall25'].includes(currentMetaRelease)) {
+      META_RELEASES_WITH_IS_NEW.includes(currentMetaRelease)) {
     isNew = enrichment.first_release === currentMetaRelease;
   }
 
@@ -128,7 +129,7 @@ function enrichAPI(api, landscape, currentMetaRelease = null) {
     // Include previous names if this was matched via previous name
     ...(enrichment.previous_names ? { previous_names: enrichment.previous_names } : {}),
     // Add isNew for meta-release reports
-    ...(currentMetaRelease && ['Fall24', 'Spring25', 'Fall25'].includes(currentMetaRelease) ? {
+    ...(currentMetaRelease && META_RELEASES_WITH_IS_NEW.includes(currentMetaRelease) ? {
       isNew: isNew
     } : {})
   };

--- a/workflows/release-collector/staging-index.html
+++ b/workflows/release-collector/staging-index.html
@@ -29,9 +29,10 @@
 
   <h2>Staging Viewers (Preview)</h2>
   <p>Review these before production deployment</p>
+  <a href="spring26.html" class="viewer-link">Spring26 meta-release (Staging)</a>
   <a href="fall25.html" class="viewer-link">Fall25 meta-release (Staging)</a>
   <a href="spring25.html" class="viewer-link">Spring25 meta-release (Staging)</a>
-  <a href="fall24.html" class="viewer-link">Fall24 meta-release(Staging)</a>
+  <a href="fall24.html" class="viewer-link">Fall24 meta-release (Staging)</a>
   <a href="portfolio.html" class="viewer-link">Portfolio (Staging)</a>
   <a href="internal.html" class="viewer-link">Internal Admin View (Staging Only)</a>
 

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -669,6 +669,7 @@
               <option value="Fall24">Fall24</option>
               <option value="Spring25">Spring25</option>
               <option value="Fall25">Fall25</option>
+              <option value="Spring26">Spring26</option>
               <option value="Independent">Independent</option>
             </select>
           </div>

--- a/workflows/release-collector/tests/test_spring26_meta_release_viewer.py
+++ b/workflows/release-collector/tests/test_spring26_meta_release_viewer.py
@@ -1,0 +1,81 @@
+import re
+from pathlib import Path
+
+
+RELEASE_COLLECTOR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_META_RELEASES = ["Fall24", "Spring25", "Fall25", "Spring26"]
+EXPECTED_VIEWERS = ["fall24", "spring25", "fall25", "spring26"]
+
+
+def read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def js_array(source, name):
+    match = re.search(
+        rf"const {re.escape(name)} = \[([^\]]+)\];",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match is not None, f"{name} constant not found"
+    return re.findall(r"['\"]([^'\"]+)['\"]", match.group(1))
+
+
+def meta_release_links(source):
+    links = re.findall(
+        r'<a href="([^"]+)" class="viewer-link">([^<]*meta-release[^<]*)</a>',
+        source,
+    )
+    return [href for href, _label in links]
+
+
+def test_spring26_report_generation_and_is_new_support():
+    generate_reports = read(RELEASE_COLLECTOR / "scripts" / "generate-reports.js")
+    enrichment = read(RELEASE_COLLECTOR / "scripts" / "lib" / "enrichment.js")
+
+    assert js_array(generate_reports, "META_RELEASES") == EXPECTED_META_RELEASES
+    assert js_array(enrichment, "META_RELEASES_WITH_IS_NEW") == EXPECTED_META_RELEASES
+
+
+def test_spring26_viewer_generation_config_and_help_text():
+    generate_viewers = read(RELEASE_COLLECTOR / "scripts" / "generate-viewers.js")
+
+    assert js_array(generate_viewers, "META_RELEASE_VIEWERS") == EXPECTED_VIEWERS
+    assert "'spring26': {" in generate_viewers
+    assert "spring26.json" in generate_viewers
+    assert "spring26.html" in generate_viewers
+    assert "fall24, spring25, fall25, spring26" in generate_viewers
+
+
+def test_spring26_is_linked_from_staging_and_production_indexes():
+    staging = read(RELEASE_COLLECTOR / "staging-index.html")
+    production = read(RELEASE_COLLECTOR / "production-index.html")
+
+    assert meta_release_links(staging) == [
+        "spring26.html",
+        "fall25.html",
+        "spring25.html",
+        "fall24.html",
+    ]
+    assert meta_release_links(production) == [
+        "spring26.html",
+        "fall25.html",
+        "spring25.html",
+        "fall24.html",
+    ]
+
+
+def test_spring26_is_in_staging_pr_and_production_workflows():
+    release_collector = read(REPO_ROOT / ".github" / "workflows" / "release-collector.yml")
+    production = read(
+        REPO_ROOT / ".github" / "workflows" / "release-collector-production.yml"
+    )
+
+    assert "for viewer in fall24 spring25 fall25 spring26 portfolio internal; do" in release_collector
+    assert "Meta-release reports (Fall24, Spring25, Fall25, Spring26, All)" in release_collector
+    assert "[Spring26 Viewer]" in release_collector
+
+    assert '"viewers/spring26.html"' in production
+    assert "cp artifact/spring26.html" in production
+    assert "| spring26.html | Spring 2026 meta-release viewer |" in production


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature


#### What this PR does / why we need it:

Adds Spring26 as a fourth static meta-release output for the Release Collector, alongside Fall24, Spring25, and Fall25.

The change generates `reports/spring26.json`, enables `viewers/spring26.html`, exposes Spring26 in staging and production indexes, and updates the staging and production deployment workflows so the new viewer is validated and copied like the existing meta-release viewers.

It also keeps `isNew` enrichment active for Spring26 APIs and adds focused regression coverage for the static Spring26 report/viewer surfaces.


#### Which issue(s) this PR fixes:

Refs #100


#### Special notes for reviewers:

This keeps the current static per-meta-release model. It does not implement the broader parameterized-viewer design discussed in #100.


#### Changelog input

```
 release-note
 Add Spring26 Release Collector report and viewer outputs.
```

#### Additional documentation 

This section can be blank.



```
docs
```
