### PR TITLE
fix(release-collector): pin js-yaml dependency

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install js-yaml axios @octokit/rest
+          npm install js-yaml@4.2.0 axios @octokit/rest
 
       - name: Detect repositories and releases
         id: detect
@@ -225,7 +225,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install js-yaml axios @octokit/rest
+          npm install js-yaml@4.2.0 axios @octokit/rest
 
       - name: Analyze release group
         run: |
@@ -289,7 +289,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install js-yaml axios
+          npm install js-yaml@4.2.0 axios
 
       - name: Download repositories data
         uses: actions/download-artifact@v8
@@ -381,7 +381,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm install js-yaml
+        run: npm install js-yaml@4.2.0
 
       - name: Generate release metadata files
         env:
@@ -436,7 +436,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install js-yaml
+          npm install js-yaml@4.2.0
 
       - name: Generate HTML viewers
         env:


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Pins the Release Collector workflow installs to `js-yaml@4.2.0`.

The collector currently installs `js-yaml` without a version. After
`js-yaml@5.0.0` became the resolved version, full Release Collector runs could
skip legacy OpenAPI files that now fail parser strictness checks and then
regenerate release metadata with missing APIs.

This is the short hotfix only. It restores the parser version used by the last
known good full run while the follow-up collector hardening is handled
separately.

#### Which issue(s) this PR fixes:

Refs #263

#### Special notes for reviewers:

PR #262 was closed because it contained parser-induced API drops. After this
hotfix lands, rerun the Release Collector in full mode and review the regenerated
output before accepting release metadata changes.

#### Changelog input

```
release-note
Pin Release Collector js-yaml dependency to 4.2.0 to avoid parser-induced API drops.
```

#### Additional documentation 

This section can be blank.



```
docs
```
