### PR TITLE
fix(release-progress): detect existing stable PR

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -251,10 +251,10 @@ jobs:
           git config user.email "261643975+camara-release-automation[bot]@users.noreply.github.com"
           git fetch origin main
 
-          PR_DATA=$(gh pr list --head "${{ github.repository_owner }}:$BRANCH" \
+          PR_DATA=$(gh pr list --head "$BRANCH" \
             --state open \
-            --json number,url,title,headRefName \
-            --jq '.[0] // {}' \
+            --json number,url,title,headRefName,headRepositoryOwner \
+            --jq 'map(select(.headRepositoryOwner.login == "${{ github.repository_owner }}")) | .[0] // {}' \
             --repo "${{ github.repository }}" 2>/dev/null || echo "{}")
           PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty')
           PR_URL=$(echo "$PR_DATA" | jq -r '.url // empty')

--- a/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
+++ b/workflows/release-progress-tracker/tests/test_workflow_data_pr.py
@@ -35,7 +35,10 @@ def test_data_pr_updates_stable_branch_safely():
 
     assert "--force-with-lease=refs/heads/$BRANCH:$REMOTE_SHA" in workflow_text
     assert "origin/main..origin/$BRANCH" in workflow_text
-    assert 'gh pr list --head "${{ github.repository_owner }}:$BRANCH"' in workflow_text
+    assert 'gh pr list --head "$BRANCH"' in workflow_text
+    assert '"${{ github.repository_owner }}:$BRANCH"' not in workflow_text
+    assert "headRepositoryOwner" in workflow_text
+    assert 'map(select(.headRepositoryOwner.login == "${{ github.repository_owner }}")) | .[0] // {}' in workflow_text
 
 
 def test_data_pr_refuses_branch_with_non_automation_commits():


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Updates the Release Progress Tracker data-PR workflow so it can find an existing same-repository stable update PR after force-pushing the `release-progress-update` branch.

The previous lookup used a qualified `owner:branch` value for `gh pr list --head`, which can miss the existing PR. The workflow now searches by branch name and filters the result to the caller repository owner, so it updates the existing PR body instead of attempting to create a duplicate PR.

#### Which issue(s) this PR fixes:

N/A - no upstream issue; small proactive fix.

#### Special notes for reviewers:

Validation:
- `python -m pytest workflows/release-progress-tracker/tests/test_workflow_data_pr.py`
- `python -m pytest workflows/release-progress-tracker/tests`
- `git diff --check`

#### Changelog input

```
release-note
NONE
```

#### Additional documentation 

This section can be blank.

```
docs
```
