### PR TITLE
Add a Review Queue view to the Release Progress Tracker

### DIFF
--- a/workflows/release-progress-tracker/README.md
+++ b/workflows/release-progress-tracker/README.md
@@ -53,7 +53,11 @@ The viewer embeds shared CSS (`viewer-styles.css`) and JS (`viewer-lib.js`) from
 
 **Template**: `templates/progress-template.html` — uses `{{VIEWER_STYLES}}`, `{{VIEWER_LIBRARY}}`, and `{{PROGRESS_DATA}}` placeholders.
 
-**Features**: API-centric table, state badges, M1/M3/M4 milestone columns, filtering (state/track/maturity/text/warnings), sortable columns, URL parameters for bookmarkable views, dark mode, CSV/JSON export.
+**Features**: two tabs sharing one artifact —
+- **Release Progress**: API-centric table, state badges, M1/M3/M4 milestone columns, filtering (state/track/maturity/text/warnings), sortable columns, URL parameters for bookmarkable views, CSV/JSON export.
+- **Review Queue**: one row per ongoing release (repository + tag, states `planned`→`published`), flat and sortable, showing track/type/tag, bundled APIs, state, release-issue and snapshot dates, the assigned reviewer (or `team`), discard history (count + last reviewer), and state-adaptive review progress. Default sort is snapshot date ascending (oldest-waiting first); CSV export.
+
+Both tabs share dark mode and the shared CSS/JS.
 
 ## Tests
 

--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -197,6 +197,11 @@ properties:
               type: ["string", "null"]
             release_pr:
               type: ["object", "null"]
+              description: |
+                Current (open) Release Review PR for the tag. The assignee(s) are
+                the concrete reviewer(s); an empty list means the RM team still
+                owns the review. Checkbox counts and ready_for_review derive from
+                the PR body; review_decision approximates GitHub's PR review state.
               properties:
                 number:
                   type: integer
@@ -205,6 +210,28 @@ properties:
                 url:
                   type: string
                   format: uri
+                created_at:
+                  type: ["string", "null"]
+                  format: date-time
+                  description: Snapshot/queue-order key (Review PR creation time)
+                assignees:
+                  type: array
+                  items:
+                    type: string
+                review_decision:
+                  type: ["string", "null"]
+                  enum: ["APPROVED", "CHANGES_REQUESTED", null]
+                codeowner_checked:
+                  type: integer
+                codeowner_total:
+                  type: integer
+                ready_for_review:
+                  type: boolean
+                  description: Codeowner readiness box ("ready for RM review") ticked
+                rm_checked:
+                  type: integer
+                rm_total:
+                  type: integer
             draft_release:
               type: ["object", "null"]
               properties:
@@ -221,6 +248,28 @@ properties:
                 url:
                   type: string
                   format: uri
+                created_at:
+                  type: ["string", "null"]
+                  format: date-time
+                  description: Release-issue creation time (RI date column)
+            review_history:
+              type: ["object", "null"]
+              description: |
+                Discarded-snapshot history for the tag, recovered from closed
+                (unmerged) Review PRs so review continuity survives a discard.
+              properties:
+                discarded_count:
+                  type: integer
+                last_reviewers:
+                  type: array
+                  items:
+                    type: string
+                last_pr_url:
+                  type: ["string", "null"]
+                  format: uri
+                last_closed_at:
+                  type: ["string", "null"]
+                  format: date-time
 
         published_context:
           type: object

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -41,6 +41,7 @@ from .models import (
     ProgressState,
     PublishedContext,
 )
+from .review_pr import derive_review_decision, parse_review_pr_body
 from .state_deriver import (
     derive_state,
     extract_draft_release_url_from_issue,
@@ -224,6 +225,68 @@ def collect_historical_entries(
     return entries
 
 
+def _collect_review_prs(
+    entry: ProgressEntry,
+    api: GitHubAPI,
+    repo_name: str,
+    target_tag: str,
+    not_before: Optional[str] = None,
+) -> None:
+    """Attach current-reviewer and discard-history data from Review PRs.
+
+    Lists every Release Review PR for the tag (current + discarded — the
+    discarded ones point at deleted snapshot branches). The open PR is the
+    current review: its assignee(s) are the concrete reviewer(s), its body
+    yields codeowner readiness / RM progress, and its reviews yield the
+    decision. Closed-but-unmerged PRs are discarded snapshots; a merged PR is
+    the accepted review, not a discard.
+    """
+    prs = api.list_release_prs(repo_name, target_tag, not_before=not_before)
+    if not prs:
+        return
+
+    open_prs = [p for p in prs if p.get("state") == "open"]
+    discarded = [
+        p for p in prs
+        if p.get("state") == "closed" and not p.get("merged")
+    ]
+
+    if open_prs:
+        current = max(open_prs, key=lambda p: p.get("created_at") or "")
+        parsed = parse_review_pr_body(current.get("body"))
+        assignees = current.get("assignees", [])
+        # The RM verdict is the assigned reviewer's — no assignee, no reviews call.
+        review_decision = None
+        if assignees:
+            reviews = api.get_pr_reviews(repo_name, current["number"])
+            review_decision = derive_review_decision(reviews, assignees)
+        entry.artifacts.release_pr = {
+            "number": current.get("number"),
+            "state": current.get("state"),
+            "url": current.get("url"),
+            "created_at": current.get("created_at"),
+            "assignees": assignees,
+            "review_decision": review_decision,
+            "codeowner_checked": parsed["codeowner_checked"],
+            "codeowner_total": parsed["codeowner_total"],
+            "ready_for_review": parsed["ready_for_review"],
+            "rm_checked": parsed["rm_checked"],
+            "rm_total": parsed["rm_total"],
+        }
+
+    if discarded:
+        last = max(
+            discarded,
+            key=lambda p: (p.get("closed_at") or p.get("created_at") or ""),
+        )
+        entry.artifacts.review_history = {
+            "discarded_count": len(discarded),
+            "last_reviewers": last.get("assignees", []),
+            "last_pr_url": last.get("url"),
+            "last_closed_at": last.get("closed_at"),
+        }
+
+
 def collect_repo_progress(
     repo_name: str,
     github_url: str,
@@ -320,10 +383,14 @@ def collect_repo_progress(
     snapshot = find_matching_snapshot(snapshot_branches, target_tag)
     if snapshot:
         entry.artifacts.snapshot_branch = snapshot
-        # Find release PR for the snapshot branch
-        pr = api.find_release_pr(repo_name, snapshot)
-        if pr:
-            entry.artifacts.release_pr = pr
+
+    # Review Queue data: the current Review PR's reviewer/readiness
+    # plus discard history. Runs for every active state — a PLANNED row can carry
+    # discard history from a snapshot that was already discarded. The release-issue
+    # date bounds the PR scan (no Review PR can predate its release issue).
+    if target_tag:
+        ri_created = release_issue.get("created_at") if release_issue else None
+        _collect_review_prs(entry, api, repo_name, target_tag, not_before=ri_created)
 
     matched_draft = find_matching_draft_release(
         draft_releases, target_tag, snapshot
@@ -346,6 +413,7 @@ def collect_repo_progress(
         entry.artifacts.release_issue = {
             "number": release_issue.get("number"),
             "url": release_issue.get("url"),
+            "created_at": release_issue.get("created_at"),
         }
 
     # Cross-reference M1/M3/M4 and last published from releases-master

--- a/workflows/release-progress-tracker/scripts/github_api.py
+++ b/workflows/release-progress-tracker/scripts/github_api.py
@@ -215,33 +215,117 @@ class GitHubAPI:
             return {
                 "number": issue["number"],
                 "url": issue["html_url"],
+                "created_at": issue.get("created_at"),
                 "body": body,
                 "labels": [label.get("name", "") for label in issue.get("labels", [])],
             }
         return None
 
-    def find_release_pr(self, repo: str, snapshot_branch: str) -> Optional[Dict]:
-        """Find a PR targeting a snapshot branch (release-review → snapshot).
+    @staticmethod
+    def _normalize_pr(pr: Dict) -> Dict:
+        """Reduce a raw PR object to the fields the Review Queue needs."""
+        return {
+            "number": pr.get("number"),
+            "state": pr.get("state"),
+            "url": pr.get("html_url"),
+            "created_at": pr.get("created_at"),
+            "closed_at": pr.get("closed_at"),
+            "merged": bool(pr.get("merged_at")),
+            "assignees": [
+                a.get("login")
+                for a in (pr.get("assignees") or [])
+                if a.get("login")
+            ],
+            "body": pr.get("body") or "",
+            "base_ref": ((pr.get("base") or {}).get("ref")) or "",
+        }
 
-        Returns {number, state, url} or None.
+    def list_release_prs(
+        self,
+        repo: str,
+        target_tag: str,
+        not_before: Optional[str] = None,
+        max_pages: int = 10,
+    ) -> List[Dict]:
+        """List all Release Review PRs for a tag — open and closed, newest first.
+
+        Release Review PRs target a ``release-snapshot/{tag}-{suffix}`` branch.
+        ``/discard-snapshot`` deletes that snapshot branch, so a discarded PR
+        points at a branch that no longer exists and cannot be found by an exact
+        ``base=`` query. We therefore page the repo's PRs (newest first) and
+        match the base branch by the ``release-snapshot/{tag}-`` prefix. The
+        trailing hyphen disambiguates ``r4.1`` from ``r4.10``.
+
+        ``not_before`` (the release-issue creation timestamp) bounds the scan:
+        no Review PR for a tag can predate its release issue, so once the
+        newest-first listing reaches a PR created before it, paging stops. This
+        keeps busy repos to the current cycle's PR window instead of their whole
+        history. (A rare release-issue recreation could set a later bound and
+        omit older discarded PRs; ``max_pages`` remains the hard backstop.)
         """
-        resp = self._get(
-            f"/repos/{ORG}/{repo}/pulls",
-            params={
-                "base": snapshot_branch,
-                "state": "all",
-                "per_page": 1,
-            },
-        )
-        if resp.status_code == 404:
-            return None
-        resp.raise_for_status()
-        prs = resp.json()
-        if prs:
-            pr = prs[0]
-            return {
-                "number": pr["number"],
-                "state": pr["state"],
-                "url": pr["html_url"],
-            }
-        return None
+        prefix = f"release-snapshot/{target_tag}-"
+        prs: List[Dict] = []
+        page = 1
+        while page <= max_pages:
+            resp = self._get(
+                f"/repos/{ORG}/{repo}/pulls",
+                params={
+                    "state": "all",
+                    "sort": "created",
+                    "direction": "desc",
+                    "per_page": 100,
+                    "page": page,
+                },
+            )
+            if resp.status_code == 404:
+                return prs
+            resp.raise_for_status()
+            data = resp.json()
+            if not data:
+                break
+            reached_bound = False
+            for pr in data:
+                if not_before and (pr.get("created_at") or "") < not_before:
+                    # Newest-first: everything from here on is older than the
+                    # release issue and cannot belong to this tag.
+                    reached_bound = True
+                    break
+                base_ref = ((pr.get("base") or {}).get("ref")) or ""
+                if base_ref.startswith(prefix):
+                    prs.append(self._normalize_pr(pr))
+            if reached_bound or len(data) < 100:
+                break
+            page += 1
+        else:
+            logger.warning(
+                "%s: Review-PR listing for %s hit the %d-page cap; "
+                "older discarded PRs may be omitted",
+                repo, target_tag, max_pages,
+            )
+        return prs
+
+    def get_pr_reviews(self, repo: str, pr_number: int) -> List[Dict]:
+        """List a PR's reviews (chronological) as {user, state, submitted_at}."""
+        reviews: List[Dict] = []
+        page = 1
+        while True:
+            resp = self._get(
+                f"/repos/{ORG}/{repo}/pulls/{pr_number}/reviews",
+                params={"per_page": 100, "page": page},
+            )
+            if resp.status_code == 404:
+                return reviews
+            resp.raise_for_status()
+            data = resp.json()
+            if not data:
+                break
+            for review in data:
+                reviews.append({
+                    "user": (review.get("user") or {}).get("login"),
+                    "state": review.get("state"),
+                    "submitted_at": review.get("submitted_at"),
+                })
+            if len(data) < 100:
+                break
+            page += 1
+        return reviews

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -9,8 +9,8 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 # Single source of truth for version constants — update here only
-SCHEMA_VERSION = "1.5.0"
-COLLECTOR_VERSION = "1.5.0"
+SCHEMA_VERSION = "1.6.0"
+COLLECTOR_VERSION = "1.6.0"
 
 
 class ProgressState(Enum):
@@ -57,9 +57,15 @@ class ApiEntry:
 class ArtifactInfo:
     """Release artifacts found in the repository."""
     snapshot_branch: Optional[str] = None
-    release_pr: Optional[Dict] = None       # {number, state, url}
+    # Current (open) Release Review PR: {number, state, url, created_at,
+    # assignees, review_decision, codeowner_checked, codeowner_total,
+    # ready_for_review, rm_checked, rm_total}. None when no open Review PR.
+    release_pr: Optional[Dict] = None
     draft_release: Optional[Dict] = None    # {name, url}
-    release_issue: Optional[Dict] = None    # {number, url}
+    release_issue: Optional[Dict] = None    # {number, url, created_at}
+    # Discarded-snapshot history for the tag: {discarded_count, last_reviewers,
+    # last_pr_url, last_closed_at}. None when no snapshot was ever discarded.
+    review_history: Optional[Dict] = None
     has_caller_workflow: Optional[bool] = None  # Transient — not serialized
 
     def to_dict(self) -> Dict:
@@ -68,6 +74,7 @@ class ArtifactInfo:
             "release_pr": self.release_pr,
             "draft_release": self.draft_release,
             "release_issue": self.release_issue,
+            "review_history": self.review_history,
         }
 
 

--- a/workflows/release-progress-tracker/scripts/review_pr.py
+++ b/workflows/release-progress-tracker/scripts/review_pr.py
@@ -1,0 +1,128 @@
+"""Pure parsing of Release Review PR content.
+
+No GitHub API dependency — operates on pre-fetched PR body text and review
+lists only, mirroring state_deriver.py. Feeds the Review Queue view: the
+codeowner readiness gate, the codeowner/Release-Management checkbox progress,
+and the PR review decision.
+"""
+
+import re
+from typing import Dict, List, Optional
+
+# Section headings in release_review_pr.mustache. Checkbox counting is scoped
+# between headings so nested "What to do" bullets and the assets table never
+# get mistaken for action checkboxes.
+_CODEOWNER_HEADING = "Codeowner Actions"
+_RM_HEADING = "Release Management Actions"
+
+# A GitHub task-list checkbox at the start of a line: "- [ ]" / "* [x]".
+# The nested instruction bullets carry no "[ ]" and so never match.
+_CHECKBOX_RE = re.compile(r"^\s*[-*]\s+\[([ xX])\]\s*(.*)$")
+
+# The explicit readiness box (mustache box 3). Gating on this box — not on
+# "all three" — is correct because box 2 is optional for alpha releases.
+_READINESS_MARKER = "ready for release management review"
+
+
+def parse_review_pr_body(body: Optional[str]) -> Dict:
+    """Parse codeowner / Release-Management action state from a Review PR body.
+
+    Returns a dict with:
+    - codeowner_total / codeowner_checked: the three Codeowner Actions boxes.
+    - ready_for_review: the explicit "ready for Release Management review" box.
+    - rm_total / rm_checked: the four Release Management Actions boxes.
+    """
+    empty = {
+        "codeowner_total": 0,
+        "codeowner_checked": 0,
+        "ready_for_review": False,
+        "rm_total": 0,
+        "rm_checked": 0,
+    }
+    if not body:
+        return empty
+
+    codeowner_boxes = _checkboxes(_section(body, _CODEOWNER_HEADING))
+    rm_boxes = _checkboxes(_section(body, _RM_HEADING))
+
+    ready = any(
+        checked and _READINESS_MARKER in label.lower()
+        for checked, label in codeowner_boxes
+    )
+
+    return {
+        "codeowner_total": len(codeowner_boxes),
+        "codeowner_checked": sum(1 for checked, _ in codeowner_boxes if checked),
+        "ready_for_review": ready,
+        "rm_total": len(rm_boxes),
+        "rm_checked": sum(1 for checked, _ in rm_boxes if checked),
+    }
+
+
+def _section(body: str, heading: str) -> str:
+    """Return the text of the ``### <heading>`` section up to the next ``###``."""
+    lines = body.splitlines()
+    start = None
+    heading_re = re.compile(rf"^\s*###\s+{re.escape(heading)}\s*$")
+    for i, line in enumerate(lines):
+        if heading_re.match(line):
+            start = i + 1
+            break
+    if start is None:
+        return ""
+
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if re.match(r"^\s*###\s+", lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
+def _checkboxes(section: str) -> List[tuple]:
+    """Extract (checked, label) for each task-list checkbox in a section."""
+    boxes = []
+    for line in section.splitlines():
+        m = _CHECKBOX_RE.match(line)
+        if m:
+            boxes.append((m.group(1).lower() == "x", m.group(2).strip()))
+    return boxes
+
+
+# Review states that carry a verdict; COMMENTED / PENDING are advisory only.
+_VERDICT_STATES = frozenset({"APPROVED", "CHANGES_REQUESTED", "DISMISSED"})
+
+
+def derive_review_decision(
+    reviews: List[Dict], assignees: List[str]
+) -> Optional[str]:
+    """Reduce a PR's reviews to the verdict of its *assigned* reviewer(s).
+
+    The assignee is the concrete RM reviewer (issue design D2), so RM approval
+    means an assigned reviewer approved — not a checkbox (which codeowners can
+    also tick) nor mere team membership. Reviews by anyone who is not an
+    assignee are ignored. With no assignee there is no RM verdict.
+
+    Considers each assigned reviewer's latest verdict review (APPROVED /
+    CHANGES_REQUESTED / DISMISSED); a trailing DISMISSED clears that reviewer.
+    Any outstanding CHANGES_REQUESTED dominates, else any APPROVED wins, else
+    None (assigned but not yet reviewed). Advisory (COMMENTED / PENDING)
+    reviews are ignored.
+    """
+    assignee_set = {a for a in (assignees or []) if a}
+    if not assignee_set:
+        return None
+
+    latest: Dict[str, str] = {}
+    for review in reviews:
+        user = review.get("user")
+        state = (review.get("state") or "").upper()
+        if user in assignee_set and state in _VERDICT_STATES:
+            latest[user] = state
+
+    effective = [state for state in latest.values() if state != "DISMISSED"]
+    if "CHANGES_REQUESTED" in effective:
+        return "CHANGES_REQUESTED"
+    if "APPROVED" in effective:
+        return "APPROVED"
+    return None

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -1471,11 +1471,13 @@ tr.historical-row:hover td {
         ? '<span class="rq-ready">ready for RM review</span>'
         : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`;
 
+      // Verdict (from the assigned reviewer) when there is one; until then the
+      // RM checklist count is a rough progress indication.
       let rm;
-      if (!row.assignees.length) rm = '<span class="rq-muted">unassigned</span>';
-      else if (row.review_decision === 'CHANGES_REQUESTED') rm = '<span class="rq-changes">changes requested</span>';
+      if (row.review_decision === 'CHANGES_REQUESTED') rm = '<span class="rq-changes">changes requested</span>';
       else if (row.review_decision === 'APPROVED') rm = '<span class="rq-approved">approved ✓</span>';
-      else rm = '<span class="rq-muted">in review</span>';
+      else if (row.rm_total) rm = `<span class="rq-muted">${row.rm_checked || 0}/${row.rm_total}</span>`;
+      else rm = '<span class="rq-muted">—</span>';
 
       return `<div class="rq-prog-line"><span class="rq-prog-label">CO:</span> ${co}</div>` +
              `<div class="rq-prog-line"><span class="rq-prog-label">RM:</span> ${rm}</div>`;
@@ -1657,10 +1659,9 @@ tr.historical-row:hover td {
           : (row.ready_for_review ? 'ready for RM review' : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`);
         let rmApproval = '';
         if (row.has_pr) {
-          if (!row.assignees.length) rmApproval = 'unassigned';
-          else if (row.review_decision === 'CHANGES_REQUESTED') rmApproval = 'changes requested';
+          if (row.review_decision === 'CHANGES_REQUESTED') rmApproval = 'changes requested';
           else if (row.review_decision === 'APPROVED') rmApproval = 'approved';
-          else rmApproval = 'in review';
+          else if (row.rm_total) rmApproval = `${row.rm_checked || 0}/${row.rm_total}`;
         }
         const reviewer = row.has_pr ? (row.assignees.join(', ') || 'team') : '';
         return [

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -252,6 +252,48 @@ tr.historical-row:hover td {
 .track-footer.hidden {
   display: none;
 }
+
+/* ===== Review Queue tab ===== */
+.view-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+  border-bottom: 2px solid var(--border-light);
+}
+.view-tab {
+  background: none;
+  border: none;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+.view-tab:hover { color: var(--text-primary); }
+.view-tab.active {
+  color: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
+}
+#reviewTable td { vertical-align: top; }
+.rq-track { font-weight: 600; }
+.rq-tagtype { color: var(--text-primary); }
+.rq-type { color: var(--text-secondary); }
+.rq-api { font-size: 13px; line-height: 1.5; }
+.rq-api code { font-size: 12px; }
+.rq-muted { color: var(--text-secondary); }
+.rq-team { color: var(--text-secondary); font-style: italic; }
+.rq-reviewer { font-weight: 600; }
+.rq-nowrap { white-space: nowrap; }
+.rq-prog-line { font-size: 13px; line-height: 1.6; white-space: nowrap; }
+.rq-prog-label { color: var(--text-secondary); }
+.rq-discard-note { font-size: 12px; color: var(--text-secondary); margin-top: 3px; }
+.rq-ready { color: #1a7f37; font-weight: 600; }
+.rq-approved { color: #1a7f37; font-weight: 600; }
+.rq-changes { color: #cf222e; font-weight: 600; }
+.rq-done { color: #1a7f37; }
+.rq-discarded { color: #cf222e; font-size: 12px; margin-top: 3px; }
   </style>
 </head>
 <body>
@@ -271,6 +313,12 @@ tr.historical-row:hover td {
     </div>
 
     <div class="content" id="content">
+      <div class="view-tabs">
+        <button class="view-tab active" data-view="progress" onclick="switchView('progress')">Release Progress</button>
+        <button class="view-tab" data-view="review" onclick="switchView('review')">Review Queue</button>
+      </div>
+
+      <div id="view-progress">
       <div class="category-pills" id="trackPills"></div>
 
       <div class="filters">
@@ -341,6 +389,64 @@ tr.historical-row:hover td {
       </table>
 
       <div id="trackFooter" class="track-footer hidden"></div>
+      </div><!-- /view-progress -->
+
+      <div id="view-review" class="hidden">
+        <div class="filters">
+          <div class="filter-row">
+            <div class="filter-group">
+              <label for="reviewSearch">Search:</label>
+              <input type="text" id="reviewSearch" placeholder="Repo, API, tag or reviewer..." onkeyup="applyReviewFilters()">
+            </div>
+            <div class="filter-group">
+              <label for="reviewStateFilter">State:</label>
+              <select id="reviewStateFilter" onchange="applyReviewFilters()">
+                <option value="">All</option>
+                <option value="snapshot_active">Snapshot</option>
+                <option value="planned">Planned</option>
+                <option value="draft_ready">Draft Ready</option>
+                <option value="published">Published</option>
+              </select>
+            </div>
+            <div class="filter-group">
+              <label for="reviewTrackFilter">Track:</label>
+              <select id="reviewTrackFilter" onchange="applyReviewFilters()">
+                <option value="">All</option>
+              </select>
+            </div>
+            <div class="filter-group">
+              <label>
+                <input type="checkbox" id="reviewUnassigned" onchange="applyReviewFilters()" style="margin-right: 4px;">
+                Unassigned only
+              </label>
+            </div>
+            <button class="clear-filters-btn" onclick="clearReviewFilters()">Clear Filters</button>
+          </div>
+        </div>
+
+        <div id="reviewResultsCounter" class="results-counter hidden">
+          <div class="results-text"></div>
+          <div class="export-buttons">
+            <button class="export-btn" onclick="exportReviewCSV()">Export CSV</button>
+          </div>
+        </div>
+
+        <table id="reviewTable">
+          <thead>
+            <tr>
+              <th onclick="sortReviewTable(0)">Repository <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(1)">Track &middot; Type<br>&middot; Tag <span class="sort-arrow"></span></th>
+              <th>APIs &amp; Version(s)</th>
+              <th onclick="sortReviewTable(3)">State <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(4)">RI<br>Date <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(5)">Snapshot<br>Date <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(6)">Reviewer <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(7)">Review<br>Progress <span class="sort-arrow"></span></th>
+            </tr>
+          </thead>
+          <tbody id="reviewTableBody"></tbody>
+        </table>
+      </div><!-- /view-review -->
 
       <div id="footer-metadata" class="footer-metadata"></div>
     </div>
@@ -382,6 +488,12 @@ tr.historical-row:hover td {
     let filteredRows = [];
     let currentSort = { column: 3, ascending: true }; // Default: sort by Release State
     let currentTrackFilter = '';
+
+    // Review Queue view state
+    const REVIEW_STATES = new Set(['planned', 'snapshot_active', 'draft_ready', 'published']);
+    let reviewAllRows = [];
+    let reviewFilteredRows = [];
+    let reviewSort = { column: 5, ascending: false }; // Default: Snapshot date, newest first (no-date rows sink to bottom)
 
     /**
      * Flatten repo-centric progress data to API-centric rows.
@@ -1218,6 +1330,365 @@ tr.historical-row:hover td {
       footerDiv.innerHTML = parts.join(' | ');
     }
 
+    // ===== Review Queue view =====================================
+    // Repo/tag-grain rows (one per progress entry in an active state), flat and
+    // sortable. Parallels the progress-view machinery but targets #reviewTable
+    // and reuses the shared ViewerLib helpers and CSS.
+
+    /**
+     * Flatten progress data to one Review-Queue row per repo+tag, keeping only
+     * active states (planned -> published).
+     */
+    function flattenReviewData(data) {
+      const rows = [];
+      (data.progress || []).forEach(repo => {
+        if (!REVIEW_STATES.has(repo.state)) return;
+        const a = repo.artifacts || {};
+        const pr = a.release_pr || null;
+        const hist = a.review_history || null;
+        const ri = a.release_issue || null;
+        rows.push({
+          repository: repo.repository,
+          github_url: repo.github_url,
+          release_track: repo.release_track || '',
+          meta_release: repo.meta_release || '',
+          target_release_tag: repo.target_release_tag || '',
+          target_release_type: repo.target_release_type || '',
+          state: repo.state,
+          apis: repo.apis || [],
+          snapshot_api_versions: repo.snapshot_api_versions || null,
+          ri_date: ri ? (ri.created_at || null) : null,
+          ri_url: ri ? (ri.url || null) : null,
+          snapshot_date: pr ? (pr.created_at || null) : null,
+          pr_url: pr ? (pr.url || null) : null,
+          has_pr: !!pr,
+          assignees: pr ? (pr.assignees || []) : [],
+          review_decision: pr ? (pr.review_decision || null) : null,
+          codeowner_checked: pr ? pr.codeowner_checked : null,
+          codeowner_total: pr ? pr.codeowner_total : null,
+          ready_for_review: pr ? !!pr.ready_for_review : false,
+          rm_checked: pr ? pr.rm_checked : null,
+          rm_total: pr ? pr.rm_total : null,
+          discarded_count: hist ? (hist.discarded_count || 0) : 0,
+          last_reviewers: hist ? (hist.last_reviewers || []) : [],
+        });
+      });
+      return rows;
+    }
+
+    function reviewTrackKey(row) {
+      return row.release_track === 'independent' ? 'independent' : (row.meta_release || 'unknown');
+    }
+
+    // Lifecycle order for the release type, used for the compound-column sort.
+    function typeOrder(type) {
+      const t = (type || '').toLowerCase();
+      if (t.includes('alpha')) return 1;
+      if (t.includes('rc')) return 2;
+      if (t.includes('public')) return 3;
+      return 9;
+    }
+
+    function shortType(type) {
+      const t = (type || '').toLowerCase();
+      if (t.includes('alpha')) return 'alpha';
+      if (t.includes('rc')) return 'rc';
+      if (t.includes('public') || t.includes('stable') || t.includes('initial')) return 'public';
+      return t || '—';
+    }
+
+    function fmtDay(iso) {
+      const d = new Date(iso);
+      const pad = n => String(n).padStart(2, '0');
+      return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+    }
+
+    function renderReviewDateCell(iso, url) {
+      if (!iso) return '<span class="rq-muted">—</span>';
+      const txt = fmtDay(iso);
+      return url
+        ? `<a href="${url}" target="_blank" rel="noopener">${txt}</a>`
+        : txt;
+    }
+
+    function renderTrackTypeTagCell(row) {
+      const track = row.release_track === 'independent'
+        ? 'Independent' : (row.meta_release || '—');
+      const tag = row.target_release_tag || '—';
+      const type = shortType(row.target_release_type);
+      const typeSuffix = (type && type !== '—')
+        ? ` <span class="rq-type">(${ViewerLib.escapeHtml(type)})</span>` : '';
+      return `<div class="rq-track">${ViewerLib.escapeHtml(track)}</div>` +
+             `<div class="rq-tagtype">${ViewerLib.escapeHtml(tag)}${typeSuffix}</div>`;
+    }
+
+    function renderReviewApisCell(row) {
+      if (!row.apis.length) return '<span class="rq-muted">—</span>';
+      const shown = row.apis.slice(0, 4).map(api => {
+        const v = (row.snapshot_api_versions && row.snapshot_api_versions[api.api_name])
+          || api.target_api_version || '';
+        const ver = v ? ` <code>${ViewerLib.escapeHtml(v)}</code>` : '';
+        return `<div class="rq-api">${ViewerLib.escapeHtml(api.api_name)}${ver}</div>`;
+      }).join('');
+      const more = row.apis.length > 4
+        ? `<div class="rq-muted">+${row.apis.length - 4} more</div>` : '';
+      return shown + more;
+    }
+
+    function renderReviewStateBadge(state) {
+      const cfg = STATE_CONFIG[state] || { label: state };
+      const tooltip = STATE_TOOLTIPS[state] || '';
+      const tip = tooltip
+        ? `<span class="state-tooltip">${ViewerLib.escapeHtml(tooltip)}</span>` : '';
+      return `<span class="state-badge state-${state}">${cfg.label}${tip}</span>`;
+    }
+
+    function renderReviewerCell(row) {
+      let html;
+      if (row.has_pr) {
+        html = row.assignees.length
+          ? row.assignees.map(a => `<span class="rq-reviewer">${ViewerLib.escapeHtml(a)}</span>`).join(', ')
+          : '<span class="rq-team">team</span>';
+      } else {
+        html = '<span class="rq-muted">—</span>';
+      }
+      // Review continuity: who reviewed the last (discarded) snapshot.
+      if (row.last_reviewers.length) {
+        const who = row.last_reviewers.map(ViewerLib.escapeHtml).join(', ');
+        html += `<div class="rq-discard-note">last: ${who}</div>`;
+      }
+      return html;
+    }
+
+    // RM approval = a verdict from the PR's assigned reviewer(s) (collector-derived,
+    // scoped to the assignee — not a checkbox, which codeowners can also tick).
+    function renderReviewProgressCell(row) {
+      if (row.state === 'published') return '<span class="rq-done">done ✓</span>';
+      if (row.state === 'draft_ready') return '<span class="rq-done">draft release created</span>';
+      if (row.state !== 'snapshot_active' || !row.has_pr) return '<span class="rq-muted">—</span>';
+
+      const co = row.ready_for_review
+        ? '<span class="rq-ready">ready for RM review</span>'
+        : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`;
+
+      let rm;
+      if (!row.assignees.length) rm = '<span class="rq-muted">unassigned</span>';
+      else if (row.review_decision === 'CHANGES_REQUESTED') rm = '<span class="rq-changes">changes requested</span>';
+      else if (row.review_decision === 'APPROVED') rm = '<span class="rq-approved">approved ✓</span>';
+      else rm = '<span class="rq-muted">in review</span>';
+
+      return `<div class="rq-prog-line"><span class="rq-prog-label">CO:</span> ${co}</div>` +
+             `<div class="rq-prog-line"><span class="rq-prog-label">RM:</span> ${rm}</div>`;
+    }
+
+    function renderSnapshotDateCell(row) {
+      const date = `<span class="rq-nowrap">${renderReviewDateCell(row.snapshot_date, row.pr_url)}</span>`;
+      if (row.discarded_count > 0) {
+        return `${date}<div class="rq-discarded">discarded &times;${row.discarded_count}</div>`;
+      }
+      return date;
+    }
+
+    function renderReviewRow(row) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="${row.github_url}" target="_blank" rel="noopener">${ViewerLib.escapeHtml(row.repository)}</a></td>
+        <td>${renderTrackTypeTagCell(row)}</td>
+        <td>${renderReviewApisCell(row)}</td>
+        <td>${renderReviewStateBadge(row.state)}</td>
+        <td class="rq-nowrap">${renderReviewDateCell(row.ri_date, row.ri_url)}</td>
+        <td>${renderSnapshotDateCell(row)}</td>
+        <td>${renderReviewerCell(row)}</td>
+        <td>${renderReviewProgressCell(row)}</td>
+      `;
+      return tr;
+    }
+
+    function reviewerSortKey(row) {
+      if (row.has_pr) {
+        return row.assignees.length ? row.assignees[0].toLowerCase() : '~team';
+      }
+      return '~~none';
+    }
+
+    function sortReviewData(rows, columnIndex, ascending) {
+      const pad = n => String(n + 1).padStart(2, '0');
+      // ISO-8601 UTC timestamps compare correctly as strings; null = "no date".
+      const sortKeys = [
+        r => r.repository.toLowerCase(),                                          // 0 Repository
+        r => `${pad(trackSortKey(reviewTrackKey(r)))}|${typeOrder(r.target_release_type)}|${r.target_release_tag}`, // 1 Track·Type·Tag
+        r => (r.apis[0] ? r.apis[0].api_name.toLowerCase() : '~'),                // 2 APIs
+        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 3 State
+        r => r.ri_date || null,                                                   // 4 RI date
+        r => r.snapshot_date || null,                                             // 5 Snapshot date
+        r => reviewerSortKey(r),                                                  // 6 Reviewer
+        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 7 Review progress (by state)
+      ];
+      const getKey = sortKeys[columnIndex] || sortKeys[5];
+
+      rows.sort((a, b) => {
+        const aVal = getKey(a);
+        const bVal = getKey(b);
+        // Empty values (e.g. no snapshot/RI date) always sort last, in BOTH
+        // directions — so descending by snapshot date keeps planned/published
+        // rows at the bottom rather than jumping them to the top.
+        const aEmpty = aVal === null || aVal === undefined || aVal === '';
+        const bEmpty = bVal === null || bVal === undefined || bVal === '';
+        if (aEmpty && bEmpty) return 0;
+        if (aEmpty) return 1;
+        if (bEmpty) return -1;
+        let cmp;
+        if (typeof aVal === 'number' && typeof bVal === 'number') cmp = aVal - bVal;
+        else cmp = String(aVal).localeCompare(String(bVal));
+        return ascending ? cmp : -cmp;
+      });
+    }
+
+    function renderReviewTable(rows) {
+      sortReviewData(rows, reviewSort.column, reviewSort.ascending);
+      const tbody = document.getElementById('reviewTableBody');
+      tbody.innerHTML = '';
+      rows.forEach(row => tbody.appendChild(renderReviewRow(row)));
+      updateReviewResultsCounter(rows.length);
+    }
+
+    function updateReviewResultsCounter(count) {
+      const counter = document.getElementById('reviewResultsCounter');
+      const resultsText = counter.querySelector('.results-text');
+      if (count === 0) {
+        resultsText.textContent = 'No releases match the current filters';
+        counter.classList.add('no-results');
+      } else {
+        const repoCount = new Set(reviewFilteredRows.map(r => r.repository)).size;
+        resultsText.textContent = `Showing ${count} releases across ${repoCount} repositories`;
+        counter.classList.remove('no-results');
+      }
+      counter.classList.remove('hidden');
+    }
+
+    function buildReviewTrackOptions() {
+      const select = document.getElementById('reviewTrackFilter');
+      const counts = {};
+      reviewAllRows.forEach(r => {
+        const key = reviewTrackKey(r);
+        counts[key] = (counts[key] || 0) + 1;
+      });
+      const ordered = TRACK_ORDER.filter(t => counts[t]);
+      const unknown = Object.keys(counts).filter(t => !TRACK_ORDER.includes(t));
+      [...unknown, ...ordered].forEach(name => {
+        const label = name === 'independent' ? 'Independent' : name;
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = `${label} (${counts[name]})`;
+        select.appendChild(opt);
+      });
+    }
+
+    function applyReviewFilters() {
+      const q = document.getElementById('reviewSearch').value.toLowerCase();
+      const stateFilter = document.getElementById('reviewStateFilter').value;
+      const trackFilter = document.getElementById('reviewTrackFilter').value;
+      const unassignedOnly = document.getElementById('reviewUnassigned').checked;
+
+      reviewFilteredRows = reviewAllRows.filter(row => {
+        if (stateFilter && row.state !== stateFilter) return false;
+        if (trackFilter && reviewTrackKey(row) !== trackFilter) return false;
+        if (unassignedOnly && !(row.has_pr && row.assignees.length === 0)) return false;
+        if (q) {
+          const haystack = [
+            row.repository, row.target_release_tag,
+            row.apis.map(a => a.api_name).join(' '),
+            row.assignees.join(' '), row.last_reviewers.join(' '),
+          ].join(' ').toLowerCase();
+          if (!haystack.includes(q)) return false;
+        }
+        return true;
+      });
+
+      renderReviewTable(reviewFilteredRows);
+      updateReviewSortIndicators(reviewSort.column);
+    }
+
+    function clearReviewFilters() {
+      document.getElementById('reviewSearch').value = '';
+      document.getElementById('reviewStateFilter').value = '';
+      document.getElementById('reviewTrackFilter').value = '';
+      document.getElementById('reviewUnassigned').checked = false;
+      applyReviewFilters();
+    }
+
+    function sortReviewTable(columnIndex) {
+      if (reviewSort.column === columnIndex) {
+        reviewSort.ascending = !reviewSort.ascending;
+      } else {
+        reviewSort.column = columnIndex;
+        reviewSort.ascending = true;
+      }
+      renderReviewTable(reviewFilteredRows);
+      updateReviewSortIndicators(columnIndex);
+    }
+
+    function updateReviewSortIndicators(activeColumn) {
+      const headers = document.querySelectorAll('#reviewTable th');
+      headers.forEach((header, index) => {
+        const arrow = header.querySelector('.sort-arrow');
+        if (!arrow) return;
+        arrow.classList.remove('active-asc', 'active-desc');
+        if (index === activeColumn) {
+          arrow.classList.add(reviewSort.ascending ? 'active-asc' : 'active-desc');
+        }
+      });
+    }
+
+    function exportReviewCSV() {
+      const headers = [
+        'Repository', 'Release Track', 'Meta-Release', 'Release Type', 'Release Tag',
+        'APIs', 'State', 'RI Date', 'Snapshot Date',
+        'Reviewer', 'Codeowner Readiness', 'RM Approval',
+        'Discarded Snapshots', 'Last Reviewer',
+      ];
+      const rows = reviewFilteredRows.map(row => {
+        const apis = row.apis.map(a => {
+          const v = (row.snapshot_api_versions && row.snapshot_api_versions[a.api_name])
+            || a.target_api_version || '';
+          return v ? `${a.api_name} ${v}` : a.api_name;
+        }).join('; ');
+        const readiness = !row.has_pr ? ''
+          : (row.ready_for_review ? 'ready for RM review' : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`);
+        let rmApproval = '';
+        if (row.has_pr) {
+          if (!row.assignees.length) rmApproval = 'unassigned';
+          else if (row.review_decision === 'CHANGES_REQUESTED') rmApproval = 'changes requested';
+          else if (row.review_decision === 'APPROVED') rmApproval = 'approved';
+          else rmApproval = 'in review';
+        }
+        const reviewer = row.has_pr ? (row.assignees.join(', ') || 'team') : '';
+        return [
+          row.repository, row.release_track, row.meta_release,
+          row.target_release_type, row.target_release_tag,
+          apis, row.state,
+          row.ri_date || '', row.snapshot_date || '',
+          reviewer, readiness, rmApproval,
+          row.discarded_count || 0, row.last_reviewers.join(', '),
+        ];
+      });
+      const csv = [headers, ...rows]
+        .map(row => row.map(cell => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+      ViewerLib.downloadFile(csv, 'camara-review-queue.csv', 'text/csv');
+    }
+
+    /**
+     * Toggle between the Release Progress and Review Queue views.
+     */
+    function switchView(name) {
+      document.getElementById('view-progress').classList.toggle('hidden', name !== 'progress');
+      document.getElementById('view-review').classList.toggle('hidden', name !== 'review');
+      document.querySelectorAll('.view-tab').forEach(tab => {
+        tab.classList.toggle('active', tab.dataset.view === name);
+      });
+    }
+
     // ===== Initialization =====
 
     function initialize() {
@@ -1237,6 +1708,11 @@ tr.historical-row:hover td {
 
       applyFilters();           // calls updateHeader(), renderTable(), updateTrackPillStates()
       updateSortIndicators(currentSort.column);
+
+      // Review Queue view: built up-front, shown on tab switch.
+      reviewAllRows = flattenReviewData(PROGRESS_DATA);
+      buildReviewTrackOptions();
+      applyReviewFilters();
     }
 
     if (ViewerLib.isInIframe()) {

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -294,6 +294,8 @@ tr.historical-row:hover td {
 .rq-changes { color: #cf222e; font-weight: 600; }
 .rq-done { color: #1a7f37; }
 .rq-discarded { color: #cf222e; font-size: 12px; margin-top: 3px; }
+.table-scroll { overflow-x: auto; }
+.rq-apis { color: var(--text-secondary); font-size: 12px; cursor: help; border-bottom: 1px dotted var(--border-light); display: inline-block; margin-top: 2px; }
   </style>
 </head>
 <body>
@@ -371,6 +373,7 @@ tr.historical-row:hover td {
         </div>
       </div>
 
+      <div class="table-scroll">
       <table id="progressTable">
         <thead>
           <tr>
@@ -387,6 +390,7 @@ tr.historical-row:hover td {
         </thead>
         <tbody id="tableBody"></tbody>
       </table>
+      </div>
 
       <div id="trackFooter" class="track-footer hidden"></div>
       </div><!-- /view-progress -->
@@ -431,21 +435,22 @@ tr.historical-row:hover td {
           </div>
         </div>
 
+        <div class="table-scroll">
         <table id="reviewTable">
           <thead>
             <tr>
               <th onclick="sortReviewTable(0)">Repository <span class="sort-arrow"></span></th>
               <th onclick="sortReviewTable(1)">Track &middot; Type<br>&middot; Tag <span class="sort-arrow"></span></th>
-              <th>APIs &amp; Version(s)</th>
-              <th onclick="sortReviewTable(3)">State <span class="sort-arrow"></span></th>
-              <th onclick="sortReviewTable(4)">RI<br>Date <span class="sort-arrow"></span></th>
-              <th onclick="sortReviewTable(5)">Snapshot<br>Date <span class="sort-arrow"></span></th>
-              <th onclick="sortReviewTable(6)">Reviewer <span class="sort-arrow"></span></th>
-              <th onclick="sortReviewTable(7)">Review<br>Progress <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(2)">State <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(3)">RI<br>Date <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(4)">Snapshot<br>Date <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(5)">Reviewer <span class="sort-arrow"></span></th>
+              <th onclick="sortReviewTable(6)">Review<br>Progress <span class="sort-arrow"></span></th>
             </tr>
           </thead>
           <tbody id="reviewTableBody"></tbody>
         </table>
+        </div>
       </div><!-- /view-review -->
 
       <div id="footer-metadata" class="footer-metadata"></div>
@@ -493,7 +498,7 @@ tr.historical-row:hover td {
     const REVIEW_STATES = new Set(['planned', 'snapshot_active', 'draft_ready', 'published']);
     let reviewAllRows = [];
     let reviewFilteredRows = [];
-    let reviewSort = { column: 5, ascending: false }; // Default: Snapshot date, newest first (no-date rows sink to bottom)
+    let reviewSort = { column: 4, ascending: false }; // Default: Snapshot date, newest first (no-date rows sink to bottom)
 
     /**
      * Flatten repo-centric progress data to API-centric rows.
@@ -1418,21 +1423,22 @@ tr.historical-row:hover td {
       const type = shortType(row.target_release_type);
       const typeSuffix = (type && type !== '—')
         ? ` <span class="rq-type">(${ViewerLib.escapeHtml(type)})</span>` : '';
+      // Bundled APIs live in a hover on the release to keep the table narrow;
+      // the full list is still in the CSV export.
+      const apis = row.apis || [];
+      let apisLine = '';
+      if (apis.length) {
+        const list = apis.map(a => {
+          const v = (row.snapshot_api_versions && row.snapshot_api_versions[a.api_name])
+            || a.target_api_version || '';
+          return v ? `${a.api_name} ${v}` : a.api_name;
+        }).join('\n');
+        apisLine = `<div class="rq-apis" title="${ViewerLib.escapeHtml(list)}">` +
+                   `${apis.length} API${apis.length > 1 ? 's' : ''}</div>`;
+      }
       return `<div class="rq-track">${ViewerLib.escapeHtml(track)}</div>` +
-             `<div class="rq-tagtype">${ViewerLib.escapeHtml(tag)}${typeSuffix}</div>`;
-    }
-
-    function renderReviewApisCell(row) {
-      if (!row.apis.length) return '<span class="rq-muted">—</span>';
-      const shown = row.apis.slice(0, 4).map(api => {
-        const v = (row.snapshot_api_versions && row.snapshot_api_versions[api.api_name])
-          || api.target_api_version || '';
-        const ver = v ? ` <code>${ViewerLib.escapeHtml(v)}</code>` : '';
-        return `<div class="rq-api">${ViewerLib.escapeHtml(api.api_name)}${ver}</div>`;
-      }).join('');
-      const more = row.apis.length > 4
-        ? `<div class="rq-muted">+${row.apis.length - 4} more</div>` : '';
-      return shown + more;
+             `<div class="rq-tagtype">${ViewerLib.escapeHtml(tag)}${typeSuffix}</div>` +
+             apisLine;
     }
 
     function renderReviewStateBadge(state) {
@@ -1496,7 +1502,6 @@ tr.historical-row:hover td {
       tr.innerHTML = `
         <td><a href="${row.github_url}" target="_blank" rel="noopener">${ViewerLib.escapeHtml(row.repository)}</a></td>
         <td>${renderTrackTypeTagCell(row)}</td>
-        <td>${renderReviewApisCell(row)}</td>
         <td>${renderReviewStateBadge(row.state)}</td>
         <td class="rq-nowrap">${renderReviewDateCell(row.ri_date, row.ri_url)}</td>
         <td>${renderSnapshotDateCell(row)}</td>
@@ -1519,14 +1524,13 @@ tr.historical-row:hover td {
       const sortKeys = [
         r => r.repository.toLowerCase(),                                          // 0 Repository
         r => `${pad(trackSortKey(reviewTrackKey(r)))}|${typeOrder(r.target_release_type)}|${r.target_release_tag}`, // 1 Track·Type·Tag
-        r => (r.apis[0] ? r.apis[0].api_name.toLowerCase() : '~'),                // 2 APIs
-        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 3 State
-        r => r.ri_date || null,                                                   // 4 RI date
-        r => r.snapshot_date || null,                                             // 5 Snapshot date
-        r => reviewerSortKey(r),                                                  // 6 Reviewer
-        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 7 Review progress (by state)
+        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 2 State
+        r => r.ri_date || null,                                                   // 3 RI date
+        r => r.snapshot_date || null,                                             // 4 Snapshot date
+        r => reviewerSortKey(r),                                                  // 5 Reviewer
+        r => (STATE_CONFIG[r.state] || {}).order ?? 99,                           // 6 Review progress (by state)
       ];
-      const getKey = sortKeys[columnIndex] || sortKeys[5];
+      const getKey = sortKeys[columnIndex] || sortKeys[4];
 
       rows.sort((a, b) => {
         const aVal = getKey(a);

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -101,13 +101,16 @@ class MockGitHubAPI:
     """Mock GitHub API for testing."""
 
     def __init__(self, file_contents=None, branches=None, tags=None,
-                 draft_releases=None, release_issues=None, release_prs=None):
+                 draft_releases=None, release_issues=None, review_prs=None,
+                 pr_reviews=None):
         self.file_contents = file_contents or {}
         self.branches = branches or {}
         self.tags = tags or set()
         self.draft_releases = draft_releases or {}
         self.release_issues = release_issues or {}
-        self.release_prs = release_prs or {}
+        self.review_prs = review_prs or {}   # repo -> [normalized PR dict]
+        self.pr_reviews = pr_reviews or {}    # (repo, number) -> [review dict]
+        self.reviews_fetched = set()          # (repo, number) get_pr_reviews was called for
         self.api_calls = 0
 
     def get_file_content(self, repo, path, ref="main"):
@@ -131,9 +134,33 @@ class MockGitHubAPI:
         self.api_calls += 1
         return self.release_issues.get(repo)
 
-    def find_release_pr(self, repo, snapshot_branch):
+    def list_release_prs(self, repo, target_tag=None, not_before=None, max_pages=10):
         self.api_calls += 1
-        return self.release_prs.get(f"{repo}/{snapshot_branch}")
+        self.last_not_before = not_before
+        return list(self.review_prs.get(repo, []))
+
+    def get_pr_reviews(self, repo, pr_number):
+        self.api_calls += 1
+        self.reviews_fetched.add((repo, pr_number))
+        return list(self.pr_reviews.get((repo, pr_number), []))
+
+
+def _review_pr(number, state, base_ref, *, merged=False, assignees=(),
+               body="", created_at="2026-07-01T00:00:00Z",
+               closed_at=None):
+    """Build a normalized Review-PR dict as list_release_prs would return."""
+    return {
+        "number": number,
+        "state": state,
+        "url": f"https://github.com/camaraproject/QualityOnDemand/pull/{number}",
+        "created_at": created_at,
+        "closed_at": closed_at if closed_at is not None
+        else (None if state == "open" else "2026-07-05T00:00:00Z"),
+        "merged": merged,
+        "assignees": list(assignees),
+        "body": body,
+        "base_ref": base_ref,
+    }
 
 
 # --- Tests ---
@@ -192,10 +219,9 @@ class TestCollectRepoProgress:
         api = MockGitHubAPI(
             file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
             branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123", "main"]},
-            release_prs={"QualityOnDemand/release-snapshot/r4.1-abc123": {
-                "number": 42, "state": "open",
-                "url": "https://github.com/camaraproject/QualityOnDemand/pull/42",
-            }},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc123", assignees=["alice"],
+            )]},
         )
         result = collect_repo_progress(
             "QualityOnDemand",
@@ -205,6 +231,169 @@ class TestCollectRepoProgress:
         assert result.state == ProgressState.SNAPSHOT_ACTIVE
         assert result.artifacts.snapshot_branch == "release-snapshot/r4.1-abc123"
         assert result.artifacts.release_pr["number"] == 42
+        assert result.artifacts.release_pr["assignees"] == ["alice"]
+
+    def test_current_reviewer_readiness_and_decision(self):
+        body = (
+            "### Codeowner Actions\n\n"
+            "- [x] **Update the CHANGELOG**\n"
+            "- [ ] **Document deferred validation warnings (and hints)**\n"
+            "- [x] **The release is ready for Release Management review**\n\n"
+            "### Release Management Actions\n\n"
+            "- [x] CHANGELOG follows the rules\n"
+            "- [ ] Breaking changes documented\n"
+            "- [ ] Assets present\n"
+            "- [ ] Warnings documented\n"
+        )
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123"]},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc123",
+                assignees=["alice"], body=body,
+            )]},
+            pr_reviews={("QualityOnDemand", 42): [
+                {"user": "kevin", "state": "APPROVED"},          # codeowner — ignored
+                {"user": "alice", "state": "CHANGES_REQUESTED"},  # assignee — decisive
+            ]},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        pr = result.artifacts.release_pr
+        assert pr["assignees"] == ["alice"]
+        assert pr["ready_for_review"] is True
+        assert pr["codeowner_checked"] == 2
+        assert pr["codeowner_total"] == 3
+        # Verdict is the assignee's (alice), not the codeowner's (kevin).
+        assert pr["review_decision"] == "CHANGES_REQUESTED"
+        assert result.artifacts.review_history is None
+
+    def test_unassigned_pr_skips_reviews_and_has_no_verdict(self):
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123"]},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc123", assignees=[])]},
+            pr_reviews={("QualityOnDemand", 42): [
+                {"user": "kevin", "state": "APPROVED"},  # codeowner approved
+            ]},
+        )
+        calls_before = api.api_calls
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        pr = result.artifacts.release_pr
+        assert pr["assignees"] == []
+        assert pr["review_decision"] is None      # unassigned -> no RM verdict
+        # get_pr_reviews must not be called for an unassigned PR (efficiency).
+        assert ("QualityOnDemand", 42) not in api.reviews_fetched
+
+    def test_discard_history_from_closed_unmerged_prs(self):
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-newsha"]},
+            review_prs={"QualityOnDemand": [
+                _review_pr(45, "open", "release-snapshot/r4.1-newsha",
+                           assignees=["alice"]),
+                _review_pr(43, "closed", "release-snapshot/r4.1-mid",
+                           assignees=["bob"], created_at="2026-06-20T00:00:00Z",
+                           closed_at="2026-06-25T00:00:00Z"),
+                _review_pr(40, "closed", "release-snapshot/r4.1-old",
+                           assignees=["carol"], created_at="2026-06-10T00:00:00Z",
+                           closed_at="2026-06-12T00:00:00Z"),
+            ]},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        assert result.artifacts.release_pr["number"] == 45
+        hist = result.artifacts.review_history
+        assert hist["discarded_count"] == 2
+        assert hist["last_reviewers"] == ["bob"]   # most-recently closed discard
+        assert hist["last_pr_url"].endswith("/pull/43")
+
+    def test_planned_row_keeps_discard_history_without_current_pr(self):
+        # Snapshot discarded -> back to PLANNED (branch gone), but the closed
+        # Review PR still records who reviewed it.
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            review_prs={"QualityOnDemand": [
+                _review_pr(41, "closed", "release-snapshot/r4.1-gone",
+                           assignees=["dave"], closed_at="2026-06-30T00:00:00Z"),
+            ]},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        assert result.state == ProgressState.PLANNED
+        assert result.artifacts.release_pr is None
+        assert result.artifacts.review_history["discarded_count"] == 1
+        assert result.artifacts.review_history["last_reviewers"] == ["dave"]
+
+    def test_merged_review_pr_is_not_a_discard(self):
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            tags={"QualityOnDemand/r4.1"},
+            review_prs={"QualityOnDemand": [
+                _review_pr(50, "closed", "release-snapshot/r4.1-final",
+                           merged=True, assignees=["alice"]),
+            ]},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, SAMPLE_MASTER["releases"], PublishedContext("r3.2", "r4.1"),
+        )
+        assert result.state == ProgressState.PUBLISHED
+        assert result.artifacts.review_history is None
+        assert result.artifacts.release_pr is None
+
+    def test_release_issue_created_at_captured(self):
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            release_issues={"QualityOnDemand": {
+                "number": 90,
+                "url": "https://github.com/camaraproject/QualityOnDemand/issues/90",
+                "created_at": "2026-06-01T09:00:00Z",
+                "labels": ["release-issue"],
+                "body": (
+                    "<!-- release-automation:workflow-owned -->\n"
+                    "<!-- release-automation:release-tag:r4.1 -->"
+                ),
+            }},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        assert result.artifacts.release_issue["created_at"] == "2026-06-01T09:00:00Z"
+
+    def test_review_pr_scan_bounded_by_release_issue_date(self):
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc"]},
+            release_issues={"QualityOnDemand": {
+                "number": 91,
+                "url": "https://github.com/camaraproject/QualityOnDemand/issues/91",
+                "created_at": "2026-06-01T09:00:00Z",
+                "labels": ["release-issue"],
+                "body": (
+                    "<!-- release-automation:workflow-owned -->\n"
+                    "<!-- release-automation:release-tag:r4.1 -->"
+                ),
+            }},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc", assignees=["alice"])]},
+        )
+        collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        assert api.last_not_before == "2026-06-01T09:00:00Z"
 
     def test_draft_ready_state(self):
         api = MockGitHubAPI(
@@ -257,6 +446,7 @@ class TestCollectRepoProgress:
         assert result.artifacts.release_issue == {
             "number": 82,
             "url": "https://github.com/camaraproject/QualityOnDemand/issues/82",
+            "created_at": None,
         }
 
     def test_published_state(self):
@@ -447,7 +637,7 @@ class TestCollectAll:
         assert "last_updated" in meta
         assert "last_checked" in meta
         assert "releases_master_updated" in meta
-        assert meta["schema_version"] == "1.5.0"
+        assert meta["schema_version"] == "1.6.0"
         assert "collection_stats" not in meta  # Full stats removed from output
         assert meta["repos_scanned"] == 2      # Stable stats restored
         assert meta["repos_with_plan"] == 2

--- a/workflows/release-progress-tracker/tests/test_github_api.py
+++ b/workflows/release-progress-tracker/tests/test_github_api.py
@@ -58,6 +58,7 @@ def test_find_release_issue_retries_public_when_auth_returns_empty(monkeypatch):
         return FakeResponse(200, [{
             "number": 43,
             "html_url": "https://github.com/camaraproject/ReleaseTest/issues/43",
+            "created_at": "2026-06-01T09:00:00Z",
             "body": (
                 "<!-- release-automation:workflow-owned -->\n"
                 "<!-- release-automation:release-tag:r1.3 -->\n"
@@ -74,6 +75,7 @@ def test_find_release_issue_retries_public_when_auth_returns_empty(monkeypatch):
     assert issue == {
         "number": 43,
         "url": "https://github.com/camaraproject/ReleaseTest/issues/43",
+        "created_at": "2026-06-01T09:00:00Z",
         "body": (
             "<!-- release-automation:workflow-owned -->\n"
             "<!-- release-automation:release-tag:r1.3 -->\n"
@@ -144,3 +146,119 @@ def test_request_raises_rate_limit_immediately_no_retry():
     with pytest.raises(RateLimitError):
         api._get("/some/path")
     assert api.api_calls == 1
+
+
+# Review-PR listing for the Review Queue ----------------------------
+
+
+def _pr(number, state, base_ref, *, merged_at=None, assignees=(), created_at="2026-07-01T00:00:00Z"):
+    return {
+        "number": number,
+        "state": state,
+        "html_url": f"https://github.com/camaraproject/QualityOnDemand/pull/{number}",
+        "created_at": created_at,
+        "closed_at": None if state == "open" else "2026-07-05T00:00:00Z",
+        "merged_at": merged_at,
+        "assignees": [{"login": login} for login in assignees],
+        "body": "review body",
+        "base": {"ref": base_ref},
+    }
+
+
+def test_list_release_prs_matches_tag_prefix_across_states(monkeypatch):
+    api = GitHubAPI(token="t")
+    page = [
+        _pr(42, "open", "release-snapshot/r4.1-newsha", assignees=["alice"]),
+        _pr(40, "closed", "release-snapshot/r4.1-oldsha", assignees=["bob"]),   # discarded
+        _pr(39, "closed", "main", merged_at="2026-06-19T12:00:00Z"),            # unrelated
+        _pr(38, "open", "release-snapshot/r4.10-xyz"),                          # different tag
+    ]
+
+    def fake_get(path, public=False, params=None, **kwargs):
+        assert path.endswith("/pulls")
+        assert params["state"] == "all"
+        return FakeResponse(200, page if params.get("page", 1) == 1 else [])
+
+    monkeypatch.setattr(api, "_get", fake_get)
+
+    prs = api.list_release_prs("QualityOnDemand", "r4.1")
+
+    # Only the two r4.1 snapshot PRs; r4.10 (prefix disambiguation) and main excluded.
+    assert [p["number"] for p in prs] == [42, 40]
+    current, discarded = prs
+    assert current["state"] == "open"
+    assert current["assignees"] == ["alice"]
+    assert current["merged"] is False
+    assert discarded["state"] == "closed"
+    assert discarded["assignees"] == ["bob"]
+    assert discarded["merged"] is False
+    assert discarded["base_ref"] == "release-snapshot/r4.1-oldsha"
+
+
+def test_list_release_prs_paginates(monkeypatch):
+    api = GitHubAPI(token="t")
+    full_page = [_pr(1000 + i, "closed", "main") for i in range(100)]
+    match = _pr(50, "closed", "release-snapshot/r4.1-abc", assignees=["carol"])
+
+    def fake_get(path, public=False, params=None, **kwargs):
+        if params.get("page", 1) == 1:
+            return FakeResponse(200, full_page)   # 100 -> forces page 2
+        if params["page"] == 2:
+            return FakeResponse(200, [match])      # <100 -> stop
+        raise AssertionError("should not fetch page 3")
+
+    monkeypatch.setattr(api, "_get", fake_get)
+
+    prs = api.list_release_prs("QualityOnDemand", "r4.1")
+    assert [p["number"] for p in prs] == [50]
+
+
+def test_list_release_prs_404_returns_empty(monkeypatch):
+    api = GitHubAPI(token="t")
+    monkeypatch.setattr(api, "_get", lambda *a, **k: FakeResponse(404, None))
+    assert api.list_release_prs("QualityOnDemand", "r4.1") == []
+
+
+def test_list_release_prs_stops_at_release_issue_date(monkeypatch):
+    api = GitHubAPI(token="t")
+    # A full page (100) sorted newest-first: one recent Review PR, then 99 older
+    # PRs predating the release issue. The not_before cutoff must exclude the old
+    # ones AND halt paging (no Review PR can predate its release issue).
+    page1 = [_pr(42, "open", "release-snapshot/r4.1-new",
+                 created_at="2026-07-01T00:00:00Z", assignees=["alice"])]
+    page1 += [_pr(1000 + i, "closed", "main", created_at="2026-05-01T00:00:00Z")
+              for i in range(99)]
+
+    fetched = []
+
+    def fake_get(path, public=False, params=None, **kwargs):
+        fetched.append(params.get("page", 1))
+        return FakeResponse(200, page1 if params.get("page", 1) == 1 else [])
+
+    monkeypatch.setattr(api, "_get", fake_get)
+
+    prs = api.list_release_prs("QualityOnDemand", "r4.1",
+                               not_before="2026-06-15T00:00:00Z")
+    assert [p["number"] for p in prs] == [42]   # pre-release-issue PRs excluded
+    assert fetched == [1]                        # scan halted; page 2 never fetched
+
+
+def test_get_pr_reviews_normalizes(monkeypatch):
+    api = GitHubAPI(token="t")
+
+    def fake_get(path, public=False, params=None, **kwargs):
+        assert path.endswith("/pulls/42/reviews")
+        return FakeResponse(200, [
+            {"user": {"login": "alice"}, "state": "APPROVED",
+             "submitted_at": "2026-07-02T00:00:00Z"},
+            {"user": {"login": "bob"}, "state": "COMMENTED",
+             "submitted_at": "2026-07-03T00:00:00Z"},
+        ])
+
+    monkeypatch.setattr(api, "_get", fake_get)
+
+    reviews = api.get_pr_reviews("QualityOnDemand", 42)
+    assert reviews == [
+        {"user": "alice", "state": "APPROVED", "submitted_at": "2026-07-02T00:00:00Z"},
+        {"user": "bob", "state": "COMMENTED", "submitted_at": "2026-07-03T00:00:00Z"},
+    ]

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -47,6 +47,7 @@ class TestArtifactInfo:
         d = a.to_dict()
         assert d["snapshot_branch"] is None
         assert d["release_pr"] is None
+        assert d["review_history"] is None
 
     def test_populated_artifacts(self):
         a = ArtifactInfo(
@@ -56,6 +57,29 @@ class TestArtifactInfo:
         d = a.to_dict()
         assert d["snapshot_branch"] == "release-snapshot/r4.1-abc"
         assert d["release_pr"]["number"] == 42
+
+    def test_review_history_and_enriched_release_pr(self):
+        a = ArtifactInfo(
+            snapshot_branch="release-snapshot/r4.1-abc",
+            release_pr={
+                "number": 42, "state": "open", "url": "https://example.com/42",
+                "created_at": "2026-07-01T00:00:00Z", "assignees": ["alice"],
+                "review_decision": "APPROVED",
+                "codeowner_checked": 2, "codeowner_total": 3, "ready_for_review": True,
+                "rm_checked": 1, "rm_total": 4,
+            },
+            review_history={
+                "discarded_count": 1, "last_reviewers": ["bob"],
+                "last_pr_url": "https://example.com/40",
+                "last_closed_at": "2026-06-25T00:00:00Z",
+            },
+        )
+        d = a.to_dict()
+        assert d["release_pr"]["review_decision"] == "APPROVED"
+        assert d["release_pr"]["ready_for_review"] is True
+        assert d["release_pr"]["assignees"] == ["alice"]
+        assert d["review_history"]["discarded_count"] == 1
+        assert d["review_history"]["last_reviewers"] == ["bob"]
 
 
 class TestCycleReleases:
@@ -158,7 +182,7 @@ class TestProgressData:
         )
         d = data.to_dict()
 
-        assert d["metadata"]["schema_version"] == "1.5.0"
+        assert d["metadata"]["schema_version"] == "1.6.0"
         assert d["metadata"]["last_checked"] == "2026-03-15T10:00:00Z"
         assert d["metadata"]["releases_master_updated"] == "2026-03-15T04:35:00Z"
         assert "collection_stats" not in d["metadata"]  # Full stats removed from output
@@ -172,7 +196,7 @@ class TestProgressData:
         # Full YAML round-trip
         yaml_str = yaml.dump(d, default_flow_style=False, sort_keys=False)
         reloaded = yaml.safe_load(yaml_str)
-        assert reloaded["metadata"]["collector_version"] == "1.5.0"
+        assert reloaded["metadata"]["collector_version"] == "1.6.0"
 
 
 class TestNewStates:

--- a/workflows/release-progress-tracker/tests/test_review_pr.py
+++ b/workflows/release-progress-tracker/tests/test_review_pr.py
@@ -1,0 +1,163 @@
+"""Tests for Review-PR body parsing and review-decision derivation."""
+
+from scripts.review_pr import derive_review_decision, parse_review_pr_body
+
+
+# A representative rendered Release Review PR body (release_review_pr.mustache),
+# with the CHANGELOG + readiness codeowner boxes ticked (box 2 left open, as is
+# valid for alpha) and 2 of 4 Release Management boxes ticked.
+REVIEW_BODY = """## Release Review: r4.1 rc
+
+This PR finalizes the reviewable release content for the active snapshot.
+
+### Release contents
+
+| API | Version | Status | Comparison target |
+|-----|---------|--------|---------------------|
+| QualityOnDemand | `v0.11.0` | rc | `r3.2` |
+
+### Codeowner Actions
+
+_Tick each box once done. Ticking the last box — "The release is ready for Release Management review" — starts the Release Management review._
+
+- [x] **Update the CHANGELOG**
+
+  What to do:
+  - Copy all API-consumer-relevant changes from the provided list.
+  - Do not copy administrative, tooling-only, or internal maintenance changes.
+
+- [ ] **Document deferred validation warnings (and hints)**
+
+  What to do:
+  - Check the CAMARA Validation comment on this PR for warnings and hints.
+
+- [x] **The release is ready for Release Management review**
+
+  Check that:
+  - All mandatory release assets for the declared status(es) are present.
+
+### Release Management Actions
+
+- [x] CHANGELOG follows the release documentation rules
+- [ ] Breaking changes are documented and version updates follow SemVer rules
+- [x] Mandatory release assets are present for each API according to its status
+- [ ] All remaining validation warnings are documented in issues and the reasons for deferral are defensible
+
+<details>
+<summary><b>Required release assets per API status</b></summary>
+
+| Nr | Asset | alpha | rc | initial<br>public | stable<br>public |
+|----|-------|:-----:|:--:|:-------:|:------:|
+| 1 | Release Plan | M | M | M | M |
+| 2 | API Definition(s) | M | M | M | M |
+
+</details>
+
+### Valid next actions for codeowners
+
+- **Merge this PR** when all Codeowner Actions and Release Management Actions are complete
+- Use **`/discard-snapshot <reason>`** to discard this snapshot
+"""
+
+
+class TestParseReviewPrBody:
+    def test_full_body(self):
+        parsed = parse_review_pr_body(REVIEW_BODY)
+        assert parsed["codeowner_total"] == 3
+        assert parsed["codeowner_checked"] == 2
+        assert parsed["ready_for_review"] is True
+        assert parsed["rm_total"] == 4
+        assert parsed["rm_checked"] == 2
+
+    def test_not_ready_when_readiness_box_unticked(self):
+        body = REVIEW_BODY.replace(
+            "- [x] **The release is ready for Release Management review**",
+            "- [ ] **The release is ready for Release Management review**",
+        )
+        parsed = parse_review_pr_body(body)
+        assert parsed["ready_for_review"] is False
+        assert parsed["codeowner_checked"] == 1
+
+    def test_uppercase_x_and_asterisk_bullets(self):
+        body = REVIEW_BODY.replace("- [x]", "* [X]")
+        parsed = parse_review_pr_body(body)
+        assert parsed["codeowner_checked"] == 2
+        assert parsed["ready_for_review"] is True
+
+    def test_nested_bullets_are_not_counted_as_checkboxes(self):
+        # The indented "What to do:" bullets have no [ ] and must not count.
+        parsed = parse_review_pr_body(REVIEW_BODY)
+        assert parsed["codeowner_total"] == 3  # not inflated by nested bullets
+
+    def test_details_table_and_next_actions_excluded_from_rm_count(self):
+        parsed = parse_review_pr_body(REVIEW_BODY)
+        assert parsed["rm_total"] == 4  # asset table rows / merge bullets excluded
+
+    def test_none_body(self):
+        parsed = parse_review_pr_body(None)
+        assert parsed == {
+            "codeowner_total": 0,
+            "codeowner_checked": 0,
+            "ready_for_review": False,
+            "rm_total": 0,
+            "rm_checked": 0,
+        }
+
+    def test_empty_body(self):
+        parsed = parse_review_pr_body("")
+        assert parsed["codeowner_total"] == 0
+        assert parsed["ready_for_review"] is False
+
+
+class TestDeriveReviewDecision:
+    def test_no_assignee_means_no_verdict(self):
+        # Unassigned PR: no designated RM reviewer, so no verdict even if approved.
+        assert derive_review_decision([{"user": "a", "state": "APPROVED"}], []) is None
+
+    def test_assigned_but_not_yet_reviewed(self):
+        assert derive_review_decision([], ["alice"]) is None
+
+    def test_assignee_approval(self):
+        reviews = [{"user": "alice", "state": "APPROVED"}]
+        assert derive_review_decision(reviews, ["alice"]) == "APPROVED"
+
+    def test_non_assignee_review_ignored(self):
+        # A codeowner (not the assignee) approving or requesting changes is ignored.
+        reviews = [
+            {"user": "bob", "state": "APPROVED"},
+            {"user": "carol", "state": "CHANGES_REQUESTED"},
+        ]
+        assert derive_review_decision(reviews, ["alice"]) is None
+
+    def test_changes_requested_dominates_among_assignees(self):
+        reviews = [
+            {"user": "alice", "state": "APPROVED"},
+            {"user": "bob", "state": "CHANGES_REQUESTED"},
+        ]
+        assert derive_review_decision(reviews, ["alice", "bob"]) == "CHANGES_REQUESTED"
+
+    def test_any_assignee_approval_when_no_changes(self):
+        # Two assigned reviewers, one approved, other not yet reviewed -> approved.
+        reviews = [{"user": "alice", "state": "APPROVED"}]
+        assert derive_review_decision(reviews, ["alice", "bob"]) == "APPROVED"
+
+    def test_latest_review_per_assignee_wins(self):
+        reviews = [
+            {"user": "alice", "state": "CHANGES_REQUESTED"},
+            {"user": "alice", "state": "APPROVED"},
+        ]
+        assert derive_review_decision(reviews, ["alice"]) == "APPROVED"
+
+    def test_dismissed_latest_means_no_effective_review(self):
+        reviews = [
+            {"user": "alice", "state": "APPROVED"},
+            {"user": "alice", "state": "DISMISSED"},
+        ]
+        assert derive_review_decision(reviews, ["alice"]) is None
+
+    def test_commented_and_pending_ignored(self):
+        reviews = [
+            {"user": "alice", "state": "COMMENTED"},
+            {"user": "alice", "state": "PENDING"},
+        ]
+        assert derive_review_decision(reviews, ["alice"]) is None


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a second **Review Queue** tab to the Release Progress Tracker so the Release Management team can distribute release reviews — see who owns each review, in what order requests arrived, and reassign as needed. It complements the existing API-centric Release Progress view without changing it.

- **Collector:** for each ongoing release (states `planned`→`published`), fetch the current Release Review PR (creation date, assignee(s), the codeowner-readiness and Release-Management checkboxes) and the release-issue date, plus the tag's closed Review PRs for discard history. The RM review verdict is taken from the PR's **assigned reviewer(s)**. Data schema bumped to 1.6.0.
- **Viewer:** a flat, sortable Review Queue tab — one row per repository + release tag — showing track/type/tag, the bundled API version(s), state, release-issue and snapshot dates, the assigned reviewer (or `team` when unassigned), discard history, and review progress. Default sort is snapshot date, newest first, with rows that have no snapshot yet kept at the bottom. Reuses the existing sort/filter/CSV machinery.

#### Which issue(s) this PR fixes:

Implements the Review Queue proposed in camaraproject/ReleaseManagement#604 (cross-repo — not auto-closed by this PR).

#### Special notes for reviewers:

- Validated end-to-end on a fork (data PR + Pages deploy) against the live meta-release data.
- "RM approved" is derived only from an APPROVED review by the PR's assigned reviewer(s) — a codeowner approval, or a ticked Release-Management checkbox, does not count.
- The Review-PR scan is bounded by the release-issue date, keeping the per-run API cost modest (~350 calls for the current ~60-repo scope).
- A companion one-line wording fix to the Review PR body template will be proposed separately in the tooling repo.

#### Changelog input

```
release-note
Add a Review Queue tab to the Release Progress Tracker for distributing release reviews across the Release Management team.
```

#### Additional documentation

```
docs

```
