### PR TITLE
Redesign the Review Queue status column with codeowner-approval detection

### DIFF
--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -201,7 +201,11 @@ properties:
                 Current (open) Release Review PR for the tag. The assignee(s) are
                 the concrete reviewer(s); an empty list means the RM team still
                 owns the review. Checkbox counts and ready_for_review derive from
-                the PR body; review_decision approximates GitHub's PR review state.
+                the PR body; review_decision approximates GitHub's PR review state
+                for the assignee(s); codeowner_approved is a separate signal for a
+                distinct codeowner's actual GitHub approval, only computed once
+                the RM axis has approved (a codeowner approving earlier doesn't
+                change anything the Review Queue displays).
               properties:
                 number:
                   type: integer
@@ -220,7 +224,17 @@ properties:
                     type: string
                 review_decision:
                   type: ["string", "null"]
-                  enum: ["APPROVED", "CHANGES_REQUESTED", null]
+                  enum: ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", null]
+                codeowner_approved:
+                  type: boolean
+                  description: |
+                    A codeowner other than the assignee(s) has an outstanding
+                    APPROVED review — the assignee's own approval never counts
+                    here (separation of duties). Defaults to false whenever
+                    review_decision isn't APPROVED, whether or not a codeowner
+                    has actually approved — false means either "checked, and
+                    no" or "not checked because it can't change what's
+                    displayed yet", not a confirmed absence of approval.
                 codeowner_checked:
                   type: integer
                 codeowner_total:

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -41,7 +41,12 @@ from .models import (
     ProgressState,
     PublishedContext,
 )
-from .review_pr import derive_review_decision, parse_review_pr_body
+from .review_pr import (
+    derive_codeowner_decision,
+    derive_review_state,
+    parse_codeowners,
+    parse_review_pr_body,
+)
 from .state_deriver import (
     derive_state,
     extract_draft_release_url_from_issue,
@@ -236,10 +241,15 @@ def _collect_review_prs(
 
     Lists every Release Review PR for the tag (current + discarded — the
     discarded ones point at deleted snapshot branches). The open PR is the
-    current review: its assignee(s) are the concrete reviewer(s), its body
-    yields codeowner readiness / RM progress, and its reviews yield the
-    decision. Closed-but-unmerged PRs are discarded snapshots; a merged PR is
-    the accepted review, not a discard.
+    current review: its assignee(s) are the concrete RM reviewer(s), its body
+    yields codeowner readiness / RM checklist progress, and its reviews yield
+    the RM decision. A distinct codeowner's approval only ever changes what
+    gets displayed once the RM reviewer has also approved (the RM axis is the
+    real gate; a codeowner approving earlier doesn't move anything forward),
+    so the CODEOWNERS lookup and the codeowner-approval check both stay
+    behind that same "RM approved" condition to avoid two API calls that
+    could never affect the output. Closed-but-unmerged PRs are discarded
+    snapshots; a merged PR is the accepted review, not a discard.
     """
     prs = api.list_release_prs(repo_name, target_tag, not_before=not_before)
     if not prs:
@@ -255,11 +265,19 @@ def _collect_review_prs(
         current = max(open_prs, key=lambda p: p.get("created_at") or "")
         parsed = parse_review_pr_body(current.get("body"))
         assignees = current.get("assignees", [])
-        # The RM verdict is the assigned reviewer's — no assignee, no reviews call.
+        # The RM state is the assigned reviewer's — no assignee, no reviews call.
         review_decision = None
+        # False here means either "checked, and no codeowner has approved" or
+        # "not checked at all" (when RM isn't approved yet) — not a confirmed
+        # absence of a codeowner approval.
+        codeowner_approved = False
         if assignees:
             reviews = api.get_pr_reviews(repo_name, current["number"])
-            review_decision = derive_review_decision(reviews, assignees)
+            review_decision = derive_review_state(reviews, assignees)
+            if review_decision == "APPROVED":
+                codeowners = parse_codeowners(api.get_codeowners(repo_name))
+                codeowner_decision = derive_codeowner_decision(reviews, codeowners, assignees)
+                codeowner_approved = codeowner_decision == "APPROVED"
         entry.artifacts.release_pr = {
             "number": current.get("number"),
             "state": current.get("state"),
@@ -267,6 +285,7 @@ def _collect_review_prs(
             "created_at": current.get("created_at"),
             "assignees": assignees,
             "review_decision": review_decision,
+            "codeowner_approved": codeowner_approved,
             "codeowner_checked": parsed["codeowner_checked"],
             "codeowner_total": parsed["codeowner_total"],
             "ready_for_review": parsed["ready_for_review"],

--- a/workflows/release-progress-tracker/scripts/github_api.py
+++ b/workflows/release-progress-tracker/scripts/github_api.py
@@ -41,6 +41,7 @@ class GitHubAPI:
         self.api_calls = 0
         # Injectable so tests can avoid real backoff sleeps.
         self._sleep = sleep
+        self._codeowners_cache: Dict[str, Optional[str]] = {}
 
     def _request(
         self,
@@ -134,6 +135,16 @@ class GitHubAPI:
         if data.get("encoding") == "base64":
             return base64.b64decode(data["content"]).decode("utf-8")
         return data.get("content")
+
+    def get_codeowners(self, repo: str) -> Optional[str]:
+        """Get a repo's CODEOWNERS file content from its default branch.
+
+        Cached per repo within a run — the Review Queue only needs one fetch
+        per repo even when a repo has more than one ongoing review row.
+        """
+        if repo not in self._codeowners_cache:
+            self._codeowners_cache[repo] = self.get_file_content(repo, "CODEOWNERS")
+        return self._codeowners_cache[repo]
 
     def list_branches(self, repo: str, prefix: str = "") -> List[str]:
         """List branch names, optionally filtered by prefix. Handles pagination."""

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -9,8 +9,8 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 # Single source of truth for version constants — update here only
-SCHEMA_VERSION = "1.6.0"
-COLLECTOR_VERSION = "1.6.0"
+SCHEMA_VERSION = "1.7.0"
+COLLECTOR_VERSION = "1.7.0"
 
 
 class ProgressState(Enum):
@@ -58,8 +58,9 @@ class ArtifactInfo:
     """Release artifacts found in the repository."""
     snapshot_branch: Optional[str] = None
     # Current (open) Release Review PR: {number, state, url, created_at,
-    # assignees, review_decision, codeowner_checked, codeowner_total,
-    # ready_for_review, rm_checked, rm_total}. None when no open Review PR.
+    # assignees, review_decision, codeowner_approved, codeowner_checked,
+    # codeowner_total, ready_for_review, rm_checked, rm_total}. None when no
+    # open Review PR.
     release_pr: Optional[Dict] = None
     draft_release: Optional[Dict] = None    # {name, url}
     release_issue: Optional[Dict] = None    # {number, url, created_at}

--- a/workflows/release-progress-tracker/scripts/review_pr.py
+++ b/workflows/release-progress-tracker/scripts/review_pr.py
@@ -126,3 +126,81 @@ def derive_review_decision(
     if "APPROVED" in effective:
         return "APPROVED"
     return None
+
+
+def derive_review_state(reviews: List[Dict], assignees: List[str]) -> Optional[str]:
+    """Reduce a PR's reviews to APPROVED / CHANGES_REQUESTED / COMMENTED / None.
+
+    Layers a "review comments" interim state onto derive_review_decision's
+    verdict reduction: a comment-only review never clears a standing verdict
+    (matches GitHub's own semantics), so COMMENTED is only surfaced when the
+    assignee has never submitted a verdict-bearing review.
+    """
+    verdict = derive_review_decision(reviews, assignees)
+    if verdict:
+        return verdict
+
+    assignee_set = {a for a in (assignees or []) if a}
+    if not assignee_set:
+        return None
+
+    has_comment = any(
+        review.get("user") in assignee_set
+        and (review.get("state") or "").upper() == "COMMENTED"
+        for review in reviews
+    )
+    return "COMMENTED" if has_comment else None
+
+
+# The tooling `/publish-release` gate's CODEOWNERS wildcard-line pattern
+# (release-automation-reusable.yml): a line that is exactly "*" or starts
+# with "* " (the root wildcard applying to all files).
+_CODEOWNERS_WILDCARD_RE = re.compile(r"^\*(\s|$)")
+_CODEOWNERS_USERNAME_RE = re.compile(r"@(\S+)")
+
+
+def parse_codeowners(content: Optional[str]) -> set:
+    """Extract the codeowner set from a CODEOWNERS file.
+
+    Mirrors tooling's `/publish-release` CODEOWNERS gate exactly: skip
+    comments and blank lines, take only the first line matching the root
+    wildcard pattern (``* @user1 @user2``), and lower-case the extracted
+    usernames. No path-aware matching or team-entry resolution.
+    """
+    if not content:
+        return set()
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _CODEOWNERS_WILDCARD_RE.match(stripped):
+            return {m.lower() for m in _CODEOWNERS_USERNAME_RE.findall(stripped)}
+    return set()
+
+
+def derive_codeowner_decision(
+    reviews: List[Dict], codeowners: set, assignees: List[str]
+) -> Optional[str]:
+    """Latest non-dismissed APPROVED from a codeowner who isn't an assignee.
+
+    Separation of duties: the RM-assigned reviewer's own approval never
+    double-counts as the codeowner approval, even when that person is also
+    listed in CODEOWNERS — the codeowner axis requires a second, distinct
+    codeowner to approve.
+    """
+    assignee_set = {a.lower() for a in (assignees or []) if a}
+    eligible = {c.lower() for c in (codeowners or [])} - assignee_set
+    if not eligible:
+        return None
+
+    latest: Dict[str, str] = {}
+    for review in reviews:
+        user = (review.get("user") or "").lower()
+        state = (review.get("state") or "").upper()
+        if user in eligible and state in _VERDICT_STATES:
+            latest[user] = state
+
+    if "APPROVED" in latest.values():
+        return "APPROVED"
+    return None

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -1486,10 +1486,10 @@ tr.historical-row:hover td {
       // A codeowner approval only becomes the relevant CO signal once RM has
       // also approved — before that, nothing can proceed on the CO axis
       // regardless of whether a codeowner already approved, so the status
-      // stays capped at "ready for RM review".
+      // stays capped at "done" (codeowner preparation finished).
       if (rm.text !== 'approved') {
         return row.ready_for_review
-          ? { text: 'ready for RM review', cls: 'rq-ready' }
+          ? { text: 'done', cls: 'rq-ready' }
           : { text: '-', cls: 'rq-muted' };
       }
       return row.codeowner_approved

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -292,6 +292,8 @@ tr.historical-row:hover td {
 .rq-ready { color: #1a7f37; font-weight: 600; }
 .rq-approved { color: #1a7f37; font-weight: 600; }
 .rq-changes { color: #cf222e; font-weight: 600; }
+.rq-comments { color: #0969da; font-weight: 600; }
+.rq-waiting { color: #9a6700; font-weight: 600; }
 .rq-done { color: #1a7f37; }
 .rq-discarded { color: #cf222e; font-size: 12px; margin-top: 3px; }
 .table-scroll { overflow-x: auto; }
@@ -1369,6 +1371,7 @@ tr.historical-row:hover td {
           has_pr: !!pr,
           assignees: pr ? (pr.assignees || []) : [],
           review_decision: pr ? (pr.review_decision || null) : null,
+          codeowner_approved: pr ? !!pr.codeowner_approved : false,
           codeowner_checked: pr ? pr.codeowner_checked : null,
           codeowner_total: pr ? pr.codeowner_total : null,
           ready_for_review: pr ? !!pr.ready_for_review : false,
@@ -1466,27 +1469,46 @@ tr.historical-row:hover td {
       return html;
     }
 
-    // RM approval = a verdict from the PR's assigned reviewer(s) (collector-derived,
-    // scoped to the assignee — not a checkbox, which codeowners can also tick).
+    // RM status derives from the assigned reviewer's own reviews
+    // (review_decision, including the 'review comments' interim state for a
+    // comment-only review before any verdict lands) — not a checkbox, which
+    // codeowners can also tick. CO status layers on top, since "waiting for
+    // approval" depends on RM already being approved.
+    function reviewRmStatus(row) {
+      if (row.review_decision === 'CHANGES_REQUESTED') return { text: 'change requested', cls: 'rq-changes' };
+      if (row.review_decision === 'APPROVED') return { text: 'approved', cls: 'rq-approved' };
+      if (row.review_decision === 'COMMENTED') return { text: 'review comments', cls: 'rq-comments' };
+      if (row.assignees.length) return { text: 'reviewer assigned', cls: 'rq-muted' };
+      return { text: '-', cls: 'rq-muted' };
+    }
+
+    function reviewCoStatus(row, rm) {
+      // A codeowner approval only becomes the relevant CO signal once RM has
+      // also approved — before that, nothing can proceed on the CO axis
+      // regardless of whether a codeowner already approved, so the status
+      // stays capped at "ready for RM review".
+      if (rm.text !== 'approved') {
+        return row.ready_for_review
+          ? { text: 'ready for RM review', cls: 'rq-ready' }
+          : { text: '-', cls: 'rq-muted' };
+      }
+      return row.codeowner_approved
+        ? { text: 'approved', cls: 'rq-approved' }
+        : { text: 'waiting for approval', cls: 'rq-waiting' };
+    }
+
     function renderReviewProgressCell(row) {
       if (row.state === 'published') return '<span class="rq-done">done ✓</span>';
       if (row.state === 'draft_ready') return '<span class="rq-done">draft release created</span>';
       if (row.state !== 'snapshot_active' || !row.has_pr) return '<span class="rq-muted">—</span>';
 
-      const co = row.ready_for_review
-        ? '<span class="rq-ready">ready for RM review</span>'
-        : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`;
-
-      // Verdict (from the assigned reviewer) when there is one; until then the
-      // RM checklist count is a rough progress indication.
-      let rm;
-      if (row.review_decision === 'CHANGES_REQUESTED') rm = '<span class="rq-changes">changes requested</span>';
-      else if (row.review_decision === 'APPROVED') rm = '<span class="rq-approved">approved ✓</span>';
-      else if (row.rm_total) rm = `<span class="rq-muted">${row.rm_checked || 0}/${row.rm_total}</span>`;
-      else rm = '<span class="rq-muted">—</span>';
-
-      return `<div class="rq-prog-line"><span class="rq-prog-label">CO:</span> ${co}</div>` +
-             `<div class="rq-prog-line"><span class="rq-prog-label">RM:</span> ${rm}</div>`;
+      const rm = reviewRmStatus(row);
+      const co = reviewCoStatus(row, rm);
+      // Always show the live checklist count and the status word together.
+      const coLine = `<span class="rq-prog-label">CO</span> ${row.codeowner_checked || 0}/${row.codeowner_total || 0} <span class="${co.cls}">${co.text}</span>`;
+      const rmLine = `<span class="rq-prog-label">RM</span> ${row.rm_checked || 0}/${row.rm_total || 0} <span class="${rm.cls}">${rm.text}</span>`;
+      return `<div class="rq-prog-line">${coLine}</div>` +
+             `<div class="rq-prog-line">${rmLine}</div>`;
     }
 
     function renderSnapshotDateCell(row) {
@@ -1659,13 +1681,13 @@ tr.historical-row:hover td {
             || a.target_api_version || '';
           return v ? `${a.api_name} ${v}` : a.api_name;
         }).join('; ');
-        const readiness = !row.has_pr ? ''
-          : (row.ready_for_review ? 'ready for RM review' : `${row.codeowner_checked || 0}/${row.codeowner_total || 3}`);
+        let readiness = '';
         let rmApproval = '';
         if (row.has_pr) {
-          if (row.review_decision === 'CHANGES_REQUESTED') rmApproval = 'changes requested';
-          else if (row.review_decision === 'APPROVED') rmApproval = 'approved';
-          else if (row.rm_total) rmApproval = `${row.rm_checked || 0}/${row.rm_total}`;
+          const rm = reviewRmStatus(row);
+          const co = reviewCoStatus(row, rm);
+          readiness = `${row.codeowner_checked || 0}/${row.codeowner_total || 0} ${co.text}`;
+          rmApproval = `${row.rm_checked || 0}/${row.rm_total || 0} ${rm.text}`;
         }
         const reviewer = row.has_pr ? (row.assignees.join(', ') || 'team') : '';
         return [

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -102,7 +102,7 @@ class MockGitHubAPI:
 
     def __init__(self, file_contents=None, branches=None, tags=None,
                  draft_releases=None, release_issues=None, review_prs=None,
-                 pr_reviews=None):
+                 pr_reviews=None, codeowners=None):
         self.file_contents = file_contents or {}
         self.branches = branches or {}
         self.tags = tags or set()
@@ -110,7 +110,9 @@ class MockGitHubAPI:
         self.release_issues = release_issues or {}
         self.review_prs = review_prs or {}   # repo -> [normalized PR dict]
         self.pr_reviews = pr_reviews or {}    # (repo, number) -> [review dict]
+        self.codeowners = codeowners or {}    # repo -> CODEOWNERS content
         self.reviews_fetched = set()          # (repo, number) get_pr_reviews was called for
+        self.codeowners_fetched = set()       # repo names get_codeowners was called for
         self.api_calls = 0
 
     def get_file_content(self, repo, path, ref="main"):
@@ -143,6 +145,11 @@ class MockGitHubAPI:
         self.api_calls += 1
         self.reviews_fetched.add((repo, pr_number))
         return list(self.pr_reviews.get((repo, pr_number), []))
+
+    def get_codeowners(self, repo):
+        self.api_calls += 1
+        self.codeowners_fetched.add(repo)
+        return self.codeowners.get(repo)
 
 
 def _review_pr(number, state, base_ref, *, merged=False, assignees=(),
@@ -269,6 +276,10 @@ class TestCollectRepoProgress:
         # Verdict is the assignee's (alice), not the codeowner's (kevin).
         assert pr["review_decision"] == "CHANGES_REQUESTED"
         assert result.artifacts.review_history is None
+        # Changes requested, not approved -> codeowner approval can't change
+        # what's displayed either way, so the CODEOWNERS lookup is skipped.
+        assert pr["codeowner_approved"] is False
+        assert "QualityOnDemand" not in api.codeowners_fetched
 
     def test_unassigned_pr_skips_reviews_and_has_no_verdict(self):
         api = MockGitHubAPI(
@@ -279,8 +290,8 @@ class TestCollectRepoProgress:
             pr_reviews={("QualityOnDemand", 42): [
                 {"user": "kevin", "state": "APPROVED"},  # codeowner approved
             ]},
+            codeowners={"QualityOnDemand": "* @kevin @rafal"},
         )
-        calls_before = api.api_calls
         result = collect_repo_progress(
             "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
             api, [], PublishedContext("r3.2", None),
@@ -288,8 +299,64 @@ class TestCollectRepoProgress:
         pr = result.artifacts.release_pr
         assert pr["assignees"] == []
         assert pr["review_decision"] is None      # unassigned -> no RM verdict
+        assert pr["codeowner_approved"] is False   # can't surface without an RM approval either
         # get_pr_reviews must not be called for an unassigned PR (efficiency).
         assert ("QualityOnDemand", 42) not in api.reviews_fetched
+        assert "QualityOnDemand" not in api.codeowners_fetched
+
+    def test_separation_of_duties_assignee_codeowner_approval_not_counted(self):
+        # kevin is both the RM assignee and a listed codeowner. His own
+        # approval satisfies the RM axis only — the codeowner axis needs a
+        # second, distinct codeowner to approve.
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123"]},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc123", assignees=["kevin"])]},
+            pr_reviews={("QualityOnDemand", 42): [
+                {"user": "kevin", "state": "APPROVED"},
+            ]},
+            codeowners={"QualityOnDemand": "* @kevin @rafal"},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        pr = result.artifacts.release_pr
+        assert pr["review_decision"] == "APPROVED"
+        assert pr["codeowner_approved"] is False
+        # RM is approved, so the CODEOWNERS lookup does need to happen here.
+        assert "QualityOnDemand" in api.codeowners_fetched
+
+        # A second, distinct codeowner approves -> codeowner axis satisfied.
+        api.pr_reviews[("QualityOnDemand", 42)].append(
+            {"user": "rafal", "state": "APPROVED"}
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        assert result.artifacts.release_pr["codeowner_approved"] is True
+
+    def test_review_decision_surfaces_comment_only_state(self):
+        # Assignee has left a comment-only review, no verdict yet.
+        api = MockGitHubAPI(
+            file_contents={"QualityOnDemand/release-plan.yaml": PLAN_RC},
+            branches={"QualityOnDemand": ["release-snapshot/r4.1-abc123"]},
+            review_prs={"QualityOnDemand": [_review_pr(
+                42, "open", "release-snapshot/r4.1-abc123", assignees=["alice"])]},
+            pr_reviews={("QualityOnDemand", 42): [
+                {"user": "alice", "state": "COMMENTED"},
+            ]},
+        )
+        result = collect_repo_progress(
+            "QualityOnDemand", "https://github.com/camaraproject/QualityOnDemand",
+            api, [], PublishedContext("r3.2", None),
+        )
+        pr = result.artifacts.release_pr
+        assert pr["review_decision"] == "COMMENTED"
+        assert pr["codeowner_approved"] is False
+        assert "QualityOnDemand" not in api.codeowners_fetched
 
     def test_discard_history_from_closed_unmerged_prs(self):
         api = MockGitHubAPI(
@@ -637,7 +704,7 @@ class TestCollectAll:
         assert "last_updated" in meta
         assert "last_checked" in meta
         assert "releases_master_updated" in meta
-        assert meta["schema_version"] == "1.6.0"
+        assert meta["schema_version"] == "1.7.0"
         assert "collection_stats" not in meta  # Full stats removed from output
         assert meta["repos_scanned"] == 2      # Stable stats restored
         assert meta["repos_with_plan"] == 2

--- a/workflows/release-progress-tracker/tests/test_github_api.py
+++ b/workflows/release-progress-tracker/tests/test_github_api.py
@@ -262,3 +262,24 @@ def test_get_pr_reviews_normalizes(monkeypatch):
         {"user": "alice", "state": "APPROVED", "submitted_at": "2026-07-02T00:00:00Z"},
         {"user": "bob", "state": "COMMENTED", "submitted_at": "2026-07-03T00:00:00Z"},
     ]
+
+
+def test_get_codeowners_caches_per_repo(monkeypatch):
+    api = GitHubAPI(token="t")
+    calls = []
+
+    def fake_get_file_content(repo, path, ref="main"):
+        calls.append((repo, path))
+        return {"QualityOnDemand": "* @alice"}.get(repo)
+
+    monkeypatch.setattr(api, "get_file_content", fake_get_file_content)
+
+    first = api.get_codeowners("QualityOnDemand")
+    second = api.get_codeowners("QualityOnDemand")
+    other_repo = api.get_codeowners("EdgeApplicationManagement")
+
+    assert first == "* @alice"
+    assert second == "* @alice"
+    assert other_repo is None
+    # One fetch per distinct repo, not per call.
+    assert calls == [("QualityOnDemand", "CODEOWNERS"), ("EdgeApplicationManagement", "CODEOWNERS")]

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -182,7 +182,7 @@ class TestProgressData:
         )
         d = data.to_dict()
 
-        assert d["metadata"]["schema_version"] == "1.6.0"
+        assert d["metadata"]["schema_version"] == "1.7.0"
         assert d["metadata"]["last_checked"] == "2026-03-15T10:00:00Z"
         assert d["metadata"]["releases_master_updated"] == "2026-03-15T04:35:00Z"
         assert "collection_stats" not in d["metadata"]  # Full stats removed from output
@@ -196,7 +196,7 @@ class TestProgressData:
         # Full YAML round-trip
         yaml_str = yaml.dump(d, default_flow_style=False, sort_keys=False)
         reloaded = yaml.safe_load(yaml_str)
-        assert reloaded["metadata"]["collector_version"] == "1.6.0"
+        assert reloaded["metadata"]["collector_version"] == "1.7.0"
 
 
 class TestNewStates:

--- a/workflows/release-progress-tracker/tests/test_review_pr.py
+++ b/workflows/release-progress-tracker/tests/test_review_pr.py
@@ -1,6 +1,12 @@
 """Tests for Review-PR body parsing and review-decision derivation."""
 
-from scripts.review_pr import derive_review_decision, parse_review_pr_body
+from scripts.review_pr import (
+    derive_codeowner_decision,
+    derive_review_decision,
+    derive_review_state,
+    parse_codeowners,
+    parse_review_pr_body,
+)
 
 
 # A representative rendered Release Review PR body (release_review_pr.mustache),
@@ -161,3 +167,127 @@ class TestDeriveReviewDecision:
             {"user": "alice", "state": "PENDING"},
         ]
         assert derive_review_decision(reviews, ["alice"]) is None
+
+
+class TestDeriveReviewState:
+    """derive_review_state layers a 'COMMENTED' interim state onto
+    derive_review_decision's verdict reduction — surfaced only when the
+    assignee has never submitted a verdict-bearing review."""
+
+    def test_no_assignee_means_no_state(self):
+        reviews = [{"user": "alice", "state": "COMMENTED"}]
+        assert derive_review_state(reviews, []) is None
+
+    def test_no_reviews_means_no_state(self):
+        # Caller distinguishes "no reviews" (None) from "no assignee" (also
+        # None) using presence of assignees for the display-level fallback.
+        assert derive_review_state([], ["alice"]) is None
+
+    def test_comment_only_surfaces_as_commented(self):
+        reviews = [{"user": "alice", "state": "COMMENTED"}]
+        assert derive_review_state(reviews, ["alice"]) == "COMMENTED"
+
+    def test_verdict_takes_priority_over_comment(self):
+        reviews = [
+            {"user": "alice", "state": "COMMENTED"},
+            {"user": "alice", "state": "APPROVED"},
+        ]
+        assert derive_review_state(reviews, ["alice"]) == "APPROVED"
+
+    def test_comment_after_verdict_does_not_clear_it(self):
+        # A comment-only review never clears a standing verdict.
+        reviews = [
+            {"user": "alice", "state": "APPROVED"},
+            {"user": "alice", "state": "COMMENTED"},
+        ]
+        assert derive_review_state(reviews, ["alice"]) == "APPROVED"
+
+    def test_non_assignee_comment_ignored(self):
+        reviews = [{"user": "bob", "state": "COMMENTED"}]
+        assert derive_review_state(reviews, ["alice"]) is None
+
+    def test_changes_requested_dominates_over_comment_from_other_assignee(self):
+        reviews = [
+            {"user": "alice", "state": "COMMENTED"},
+            {"user": "bob", "state": "CHANGES_REQUESTED"},
+        ]
+        assert derive_review_state(reviews, ["alice", "bob"]) == "CHANGES_REQUESTED"
+
+
+class TestParseCodeowners:
+    """Reuses tooling's /publish-release CODEOWNERS parse — first
+    ``* @user...`` line only, lower-cased usernames, no path-aware matching."""
+
+    def test_extracts_usernames_from_first_wildcard_line(self):
+        content = "# comment\n* @hdamker @rartych\n/docs/ @someoneelse\n"
+        assert parse_codeowners(content) == {"hdamker", "rartych"}
+
+    def test_lowercases_usernames(self):
+        assert parse_codeowners("* @HDamker") == {"hdamker"}
+
+    def test_only_first_wildcard_line_used(self):
+        content = "* @alice\n* @bob\n"
+        assert parse_codeowners(content) == {"alice"}
+
+    def test_skips_comments_and_blank_lines(self):
+        content = "\n# top comment\n\n* @alice\n"
+        assert parse_codeowners(content) == {"alice"}
+
+    def test_bare_star_with_no_owners(self):
+        assert parse_codeowners("*\n") == set()
+
+    def test_none_content_returns_empty_set(self):
+        assert parse_codeowners(None) == set()
+
+    def test_no_wildcard_line_returns_empty_set(self):
+        assert parse_codeowners("/docs/ @alice\n") == set()
+
+
+class TestDeriveCodeownerDecision:
+    """Latest non-dismissed APPROVED from codeowners_set - assignees."""
+
+    def test_codeowner_approval_detected(self):
+        reviews = [{"user": "rartych", "state": "APPROVED"}]
+        result = derive_codeowner_decision(reviews, {"hdamker", "rartych"}, ["alice"])
+        assert result == "APPROVED"
+
+    def test_no_codeowners_means_no_decision(self):
+        reviews = [{"user": "rartych", "state": "APPROVED"}]
+        assert derive_codeowner_decision(reviews, set(), ["alice"]) is None
+
+    def test_separation_of_duties_assignee_approval_not_counted(self):
+        # hdamker is both the RM assignee and a listed codeowner — their own
+        # approval never double-counts as the codeowner axis.
+        reviews = [{"user": "hdamker", "state": "APPROVED"}]
+        result = derive_codeowner_decision(
+            reviews, {"hdamker", "rartych"}, ["hdamker"],
+        )
+        assert result is None
+
+    def test_second_distinct_codeowner_satisfies_the_axis(self):
+        reviews = [
+            {"user": "hdamker", "state": "APPROVED"},
+            {"user": "rartych", "state": "APPROVED"},
+        ]
+        result = derive_codeowner_decision(
+            reviews, {"hdamker", "rartych"}, ["hdamker"],
+        )
+        assert result == "APPROVED"
+
+    def test_dismissed_codeowner_approval_not_counted(self):
+        reviews = [
+            {"user": "rartych", "state": "APPROVED"},
+            {"user": "rartych", "state": "DISMISSED"},
+        ]
+        result = derive_codeowner_decision(reviews, {"rartych"}, ["alice"])
+        assert result is None
+
+    def test_changes_requested_from_codeowner_does_not_yield_approval(self):
+        reviews = [{"user": "rartych", "state": "CHANGES_REQUESTED"}]
+        result = derive_codeowner_decision(reviews, {"rartych"}, ["alice"])
+        assert result is None
+
+    def test_case_insensitive_matching(self):
+        reviews = [{"user": "RARTYCH", "state": "APPROVED"}]
+        result = derive_codeowner_decision(reviews, {"rartych"}, ["alice"])
+        assert result == "APPROVED"


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Redesigns the Review Queue's "Review Progress" column (added in #273) to surface two signals that were previously fetched but discarded: comment-only reviews and codeowner approvals.

- Shows "review comments" when a reviewer has commented but hasn't given a verdict yet, instead of looking unreviewed.
- Shows when a codeowner has also approved, once RM has approved.
- Each line always shows the live checklist count plus a status word, so progress reads clearly even before a verdict exists.

#### Which issue(s) this PR fixes:

N/A — no upstream issue; a follow-on refinement to #273.

#### Special notes for reviewers:

- Validated end-to-end on a fork against live CAMARA repo data: [data PR](https://github.com/hdamker/ReleaseManagement/pull/61) and [viewer](https://hdamker.github.io/ReleaseManagement/progress.html)
- No changes to `tooling`.

#### Changelog input

```
release-note
Redesign the Review Queue's Review Progress column: add codeowner-approval detection and a "review comments" interim state.
```

#### Additional documentation 

This section can be blank.

```
docs

```
